### PR TITLE
Update material MCP protocol for UE5.8

### DIFF
--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -1,0 +1,8 @@
+[FilterPlugin]
+; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
+; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
+;
+; Examples:
+;    /README.txt
+;    /Extras/...
+;    /Binaries/ThirdParty/*.dll

--- a/Document/MaterialMcpProtocol.md
+++ b/Document/MaterialMcpProtocol.md
@@ -1,0 +1,149 @@
+# Material MCP Protocol Draft
+
+本文记录当前开源 Material MCP 的精简协议原则。范围限定为 UE 5.8；不引入商业版服务依赖。
+
+## 设计原则
+
+1. 默认创建 UI 材质。`material_set_target` 和 `hlsl_set_target` 创建新材质时仍使用 `MD_UI` + `Translucent`，保证 UMG 场景只给名字也能看到结果。
+2. 非 UI 材质必须显式声明。使用 `hlsl_set_target` 的 `domain`、`blend_mode`、`shading_model`、`two_sided` 参数修改当前目标材质类型。
+3. HLSL 是主路径。Material ToolMode 默认只暴露 HLSL 闭环、显式类型修改和显式删除参数，避免 AI 走低阶图编辑。
+4. 读操作返回语义，不返回完整图。`hlsl_get` 返回 HLSL、参数快照和 `output_contract`，说明 `float4` 的 rgb/a 与额外 outputs 当前连接到什么材质输出。
+5. 写操作只做并集覆盖和追加。`hlsl_set` 可以更新代码、更新已有参数类型、追加新参数、追加/更新 outputs，但不能删除。
+6. 删除必须走单独命令。统一使用 `hlsl_delete(names, confirm_delete=true, kind?)`。默认按名称语义匹配 parameter/output；如果歧义，返回失败并要求补 `kind`。
+
+## 当前精简工具
+
+| Tool | 作用 |
+| --- | --- |
+| `hlsl_set_target(path, confirm_overwrite=false, create_if_not_found=true, domain?, blend_mode?, shading_model?, two_sided?)` | 设置或创建 HLSL 材质目标。新材质默认 UI；可携带类型字段切到非 UI。已有材质必须满足单 Custom 节点拓扑，否则需要确认覆写。 |
+| `hlsl_get()` | 读取当前 HLSL、参数列表和输出契约。 |
+| `hlsl_set(hlsl?, parameters?, outputs?)` | 并集式写入 HLSL、参数与材质输出。不会删除。 |
+| `hlsl_delete(names, confirm_delete=true, kind?)` | 显式删除 HLSL 参数或输出。名称歧义时补 `kind="parameter"` 或 `kind="output"`。 |
+| `hlsl_compile()` | 编译当前材质并返回精简诊断。 |
+
+## `hlsl_set_target` 类型参数
+
+`domain` 支持：
+
+- `ui`
+- `surface`
+- `post_process`
+- `deferred_decal`
+- `light_function`
+- `volume`
+
+`blend_mode` 支持：
+
+- `opaque`
+- `masked`
+- `translucent`
+- `additive`
+- `modulate`
+- `alpha_composite`
+- `alpha_holdout`
+
+`shading_model` 支持 UE 5.8 常用模型：
+
+- `unlit`
+- `default_lit`
+- `subsurface`
+- `preintegrated_skin`
+- `clear_coat`
+- `subsurface_profile`
+- `two_sided_foliage`
+- `hair`
+- `cloth`
+- `eye`
+- `single_layer_water`
+- `thin_translucent`
+
+## 输出契约
+
+HLSL Custom 节点主返回值固定为 `float4`。后端根据材质类型生成语义契约：
+
+```json
+{
+  "return": "float4",
+  "domain": "ui",
+  "blend_mode": "translucent",
+  "shading_model": "unlit",
+  "rgb_to": "EmissiveColor",
+  "a_to": "Opacity",
+  "outputs": [
+    {"name": "Roughness", "target": "Roughness", "type": "float1", "connected": true}
+  ]
+}
+```
+
+规则：
+
+- UI、Post Process、Light Function、Unlit 材质：`rgb -> EmissiveColor`
+- 默认 Lit Surface：`rgb -> BaseColor`
+- Masked：`a -> OpacityMask`
+- 非 Opaque 且非 Masked：`a -> Opacity`
+- Opaque：不声明 alpha 输出
+
+`outputs` 是 Custom 节点的 AdditionalOutputs。HLSL 代码里使用同名 `inout` 变量赋值：
+
+```hlsl
+Roughness = 0.35;
+Metallic = 0.0;
+Normal = normalize(float3(0, 0, 1));
+return float4(BaseColorValue, 1);
+```
+
+`outputs` 最简写法是字符串数组：
+
+```json
+["Roughness", "Metallic", "Normal"]
+```
+
+需要自定义 HLSL 变量名或类型时使用对象：
+
+```json
+[
+  {"name": "ClearCoatAmount", "target": "CustomData0", "type": "float1"},
+  {"name": "BentNormal", "target": "Normal", "type": "float3"}
+]
+```
+
+常用 target 默认类型：
+
+- `BaseColor`, `EmissiveColor`, `Normal`, `Tangent`, `WorldPositionOffset`, `SubsurfaceColor`: `float3`
+- `CustomizedUVs0` 到 `CustomizedUVs7`: `float2`
+- `Metallic`, `Specular`, `Roughness`, `Anisotropy`, `Opacity`, `OpacityMask`, `AmbientOcclusion`, `Refraction`, `PixelDepthOffset`, `CustomData0`, `CustomData1`: `float1`
+
+## 非 UI 示例
+
+创建一个可见的非 UMG Surface HLSL 材质：
+
+```python
+await hlsl_set_target(
+    "/Game/Materials/M_HlslSurface",
+    domain="surface",
+    shading_model="unlit",
+    blend_mode="opaque"
+)
+await hlsl_set(
+    hlsl="Roughness = 0.25; return float4(0.1, 0.8, 1.0, 1.0);",
+    outputs=["Roughness"]
+)
+await hlsl_compile()
+```
+
+创建 Masked Surface：
+
+```python
+await hlsl_set_target(
+    "/Game/Materials/M_HlslMasked",
+    domain="surface",
+    shading_model="unlit",
+    blend_mode="masked"
+)
+await hlsl_set(hlsl="return float4(1, 1, 1, UV.x > 0.5 ? 1 : 0);")
+await hlsl_compile()
+```
+
+## 兼容层
+
+传统 `material_*` 低阶图编辑工具暂时保留作为兼容层，但 Material ToolMode 不建议使用。后续协议清理时应逐个判断是否合并、下线或转为内部实现细节。

--- a/Readme.md
+++ b/Readme.md
@@ -269,39 +269,25 @@ Notes:
 - Write paths are union/overwrite only—no implicit deletion. Use `animation_delete_widget_keys` with `confirm_delete=true` for scoped removals.
 - Responses now include counts/timeline context so every sequencer MCP returns actionable data.
 
-## UMG Material API Status (New: The 5 Core Pillars Strategy)
+## UMG Material API Status
 
-| Category                | API Name                       |  Status   | Description                                                                                     |
-| ----------------------- | ------------------------------ | :-------: | ----------------------------------------------------------------------------------------------- |
-| **P0: Context**         | `material_set_target`          |     ✅     | **Anchor**: Specify target asset (path or parent). Required for stateful editing.               |
-| **P1: Def & Query**     | `material_define_variable`     |     ✅     | Define external interface parameters (Def, not wire). Supports Scalar, Vector, Texture.         |
-| **P2: Symbol Place**    | `material_add_node`            |     ✅     | **Drag Symbol**: Place a symbol from lib into graph and assign a unique instance handle.        |
-|                         | `material_get_graph`           |     ✅     | Query existence and state of node instances in the graph.                                       |
-| **P3: Connectivity**    | `material_connect_nodes`       |     ✅     | **Natural Connection**: Establish node-to-node functional flow (A -> B).                        |
-|                         | `material_connect_pins`        |     ✅     | **Surgical Wiring**: Manually connect specific pins for complex topologies.                     |
-| **P4: Lib Search**      | `material_search_library`      | 🚧 Planned | Search for available Material Expressions (symbols) and Functions.                              |
-| **P5: Tactical Detail** | `material_set_hlsl_node_io`    |     ✅     | **Tactical Code**: Inject HLSL into Custom nodes and sync IO pins via JSON mapping.             |
-|                         | `material_set_node_properties` |     ✅     | **Property Editing**: Set internal properties for regular nodes (e.g. Constant Value, Texture). |
-| **Lifecycle**           | `material_compile_asset`       |     ✅     | Submit changes and analyze HLSL compilation errors.                                             |
-| **Maintenance**         | `material_delete`              |     ✅     | Delete node instances or clean up logic by unique handle.                                       |
-|                         | `material_get_pins`            |     ✅     | Introspect pins for a specific node handle.                                                     |
-
-## UMG HLSL MCP API Status (New: Text-Edit Loop for UMG)
-
-| Command             | Status | Description                                                                                                                           |
-| ------------------- | :----: | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `hlsl_set_target`   |   ✅    | Lock/create HLSL target material. Validates UI-domain + single Custom node topology; can request confirmation before overwrite.     |
-| `hlsl_get`          |   ✅    | Read current HLSL code and structured input parameters from the single Custom node.                                                  |
-| `hlsl_set`          |   ✅    | Incremental update of HLSL and/or parameters. Deletion is explicit (`delete: true`) to avoid accidental destructive edits.           |
-| `hlsl_compile`      |   ✅    | Compile current HLSL target and return concise diagnostics for AI post-processing.                                                   |
+| Command           | Status | Description                                                                                                      |
+| ----------------- | :----: | ---------------------------------------------------------------------------------------------------------------- |
+| `hlsl_set_target` |   ✅    | Lock/create the HLSL target material. New assets default to UI; pass type fields for non-UMG materials.          |
+| `hlsl_get`        |   ✅    | Read current HLSL code, structured parameters, and the semantic output contract.                                  |
+| `hlsl_set`        |   ✅    | Union-style write for HLSL, parameters, and extra outputs: overwrite existing items and append missing ones.      |
+| `hlsl_delete`     |   ✅    | Explicitly delete HLSL parameters or outputs with `confirm_delete=true`; add `kind` only when a name is ambiguous. |
+| `hlsl_compile`    |   ✅    | Compile current HLSL target and return concise diagnostics for AI post-processing.                                |
 
 ### HLSL Protocol Contract (UMG-Optimized)
 
 - Material is treated as a single HLSL program.
 - Backend assumes HLSL returns `float4`.
-- Output auto-wiring is fixed: `.rgb -> FinalColor`, `.a -> Opacity`.
+- Output auto-wiring is semantic: UI/Post Process/Light Function/Unlit routes rgb to `EmissiveColor`; Lit Surface routes rgb to `BaseColor`; alpha only connects to `Opacity` or `OpacityMask` when needed.
+- Extra material outputs use UE 5.8 Custom node `AdditionalOutputs`, so one HLSL block can drive `Roughness`, `Metallic`, `Normal`, `WorldPositionOffset`, and similar root outputs.
 - Input parameters are returned as structured descriptors (`name`, `kind`, `source_handle`) for learning/replay by AI agents.
-- `hlsl_set` is safety-biased: writing is easy, deletion must be explicit.
+- `hlsl_set` only performs union overwrite/append operations. Deletion must use `hlsl_delete(confirm_delete=true)`.
+- Low-level `material_*` graph tools are kept as a compatibility layer, but the Material ToolMode exposes the HLSL loop by default.
 
 ## UMG Style & Theming API Status (New)
 

--- a/Readme_zh.md
+++ b/Readme_zh.md
@@ -267,39 +267,25 @@ flowchart LR
 - 写入仅做并集/覆盖，不做隐式删除；如需删除，请使用 `animation_delete_widget_keys` 并显式传入 `confirm_delete=true`。
 - 所有动画指令都会返回有价值的计数/时间线信息，便于 AI 复述与复现。
 
-## UMG 材质 (Material) API 实现状态 (New: 五大核心能力)
+## UMG 材质 (Material) API 实现状态
 
-| 分类             | API 名称                       |   状态   | 描述                                                                   |
-| ---------------- | ------------------------------ | :------: | ---------------------------------------------------------------------- |
-| **P0: 上下文**   | `material_set_target`          |    ✅     | **锚点**：指定当前编辑的材质资产（支持自动创建/重定向）。              |
-| **P1: 输入定义** | `material_define_variable`     |    ✅     | 定义外部接口参数（定义而非连线）。支持 Scalar, Vector, Texture。       |
-| **P2: 符号放置** | `material_add_node`            |    ✅     | **拖拽符号**：将 UE5 库中的符号放置到图表并分配实例句柄（Handle）。    |
-|                  | `material_get_graph`           |    ✅     | 查询图表中的所有节点句柄及其状态。                                     |
-| **P3: 连接拓扑** | `material_connect_nodes`       |    ✅     | **自然连接**：建立节点间的逻辑映射（A -> B），模拟功能性嵌套。         |
-|                  | `material_connect_pins`        |    ✅     | **外科连线**：在复杂拓扑下手动连接特定的输入引脚。                     |
-| **P4: 符号检索** | `material_search_library`      | 🚧 计划中 | 快速检索 UE5 材质表达式库中的符号（Symbol）。                          |
-| **P5: 细节注入** | `material_set_hlsl_node_io`    |    ✅     | **战术细节**：编写 Custom 节点的 HLSL 代码并实时同步 IO 引脚。         |
-|                  | `material_set_node_properties` |    ✅     | **属性编辑**：设置常规节点（如 Constant, TextureSample）的内部属性值。 |
-| **生命周期**     | `material_compile_asset`       |    ✅     | 提交更改并分析 HLSL 报错。                                             |
-|                  | `material_delete`              |    ✅     | 根据唯一句柄删除实例。                                                 |
-| **维护**         | `material_get_pins`            |    ✅     | 内省特定节点句柄的引脚。                                               |
-
-## UMG HLSL MCP API 实现状态（新增：面向 UMG 的文本编辑闭环）
-
-| 命令              | 状态  | 描述                                                                                     |
-| ----------------- | :---: | ---------------------------------------------------------------------------------------- |
-| `hlsl_set_target` |   ✅   | 锁定/创建 HLSL 目标材质。校验 UI 材质域 + 单 Custom 节点拓扑；不匹配时可先返回覆写确认。 |
-| `hlsl_get`        |   ✅   | 读取当前 HLSL 代码和结构化输入参数信息。                                                 |
-| `hlsl_set`        |   ✅   | 对 HLSL 与/或参数做增量更新。删除必须显式标记（`delete: true`），避免误删。              |
-| `hlsl_compile`    |   ✅   | 编译当前 HLSL 目标并返回精简诊断信息，便于 AI 后处理。                                   |
+| 命令              | 状态  | 描述                                                                                         |
+| ----------------- | :---: | -------------------------------------------------------------------------------------------- |
+| `hlsl_set_target` |   ✅   | 锁定/创建 HLSL 目标材质。新材质默认 UI；非 UMG 材质可携带类型字段。                          |
+| `hlsl_get`        |   ✅   | 读取当前 HLSL 代码、结构化参数和语义输出契约。                                                |
+| `hlsl_set`        |   ✅   | 对 HLSL、参数、额外输出做并集式写入：覆盖已有项，追加缺失项。                                 |
+| `hlsl_delete`     |   ✅   | 显式删除 HLSL 参数或输出，必须传入 `confirm_delete=true`；名称歧义时再补 `kind`。             |
+| `hlsl_compile`    |   ✅   | 编译当前 HLSL 目标并返回精简诊断信息，便于 AI 后处理。                                        |
 
 ### HLSL 协议约定（UMG 垂直优化）
 
 - 材质被视作单一 HLSL 程序。
 - 后端约定 HLSL 返回 `float4`。
-- 输出自动连线固定为：`.rgb -> FinalColor`，`.a -> Opacity`。
+- 输出自动连线改为语义契约：UI/Post Process/Light Function/Unlit 使用 `EmissiveColor`；Lit Surface 使用 `BaseColor`；alpha 只在需要时接到 `Opacity` 或 `OpacityMask`。
+- 额外输出使用 UE 5.8 Custom 节点 `AdditionalOutputs`，因此一个 HLSL 块可以同时驱动 `Roughness`、`Metallic`、`Normal`、`WorldPositionOffset` 等材质根输出。
 - 输入参数以结构化描述返回（如 `name`、`kind`、`source_handle`），便于 AI 学习与复用。
-- `hlsl_set` 采用“易写难删”策略：写入简单，删除必须显式声明。
+- `hlsl_set` 只做并集覆盖和追加；删除必须使用 `hlsl_delete(confirm_delete=true)`。
+- 低阶 `material_*` 图编辑工具作为兼容层保留，但 Material ToolMode 默认只暴露 HLSL 闭环。
 
 ## UMG 样式与主题 (Style & Theming) API 实现状态 (New)
 

--- a/Resources/Python/APITest/Material_HLSL_Type_Demo.py
+++ b/Resources/Python/APITest/Material_HLSL_Type_Demo.py
@@ -1,0 +1,88 @@
+import asyncio
+import json
+import os
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+from mcp_config import UNREAL_HOST, UNREAL_PORT
+
+
+class SimpleConnection:
+    async def send_command(self, command: str, params: dict = None) -> dict:
+        reader = None
+        writer = None
+        try:
+            reader, writer = await asyncio.open_connection(UNREAL_HOST, UNREAL_PORT)
+            payload = {"command": command, "params": params or {}}
+            data = json.dumps(payload).encode("utf-8")
+            writer.write(data + b"\0")
+            await writer.drain()
+
+            chunks = []
+            while True:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                if b"\0" in chunk:
+                    chunks.append(chunk[:chunk.find(b"\0")])
+                    break
+                chunks.append(chunk)
+
+            response_data = b"".join(chunks).decode("utf-8")
+            return json.loads(response_data)
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+        finally:
+            if writer:
+                writer.close()
+                await writer.wait_closed()
+
+
+async def call(conn: SimpleConnection, command: str, params: dict = None) -> dict:
+    response = await conn.send_command(command, params)
+    print(command, json.dumps(response, ensure_ascii=False, indent=2))
+    if response.get("success") is False or response.get("status") == "error":
+        raise RuntimeError(response.get("error", f"{command} failed"))
+    return response
+
+
+async def run_demo():
+    conn = SimpleConnection()
+
+    await call(conn, "hlsl_set_target", {
+        "path": "/Game/UMGMCP/Demos/M_Hlsl_UI",
+        "create_if_not_found": True
+    })
+    await call(conn, "hlsl_set", {
+        "hlsl": "return float4(UV.x, UV.y, 1.0, 0.85);",
+        "parameters": []
+    })
+    await call(conn, "hlsl_compile")
+
+    await call(conn, "hlsl_set_target", {
+        "path": "/Game/UMGMCP/Demos/M_Hlsl_Surface",
+        "create_if_not_found": True,
+        "domain": "surface",
+        "shading_model": "unlit",
+        "blend_mode": "opaque"
+    })
+    await call(conn, "hlsl_get")
+    await call(conn, "hlsl_set", {
+        "hlsl": "\n".join([
+            "float glow = saturate(Intensity);",
+            "Roughness = 0.28;",
+            "Metallic = 0.0;",
+            "Normal = normalize(float3(0.0, 0.0, 1.0));",
+            "return float4((0.05 + UV.x * 0.7) * glow, 0.2, 1.0 - UV.y * 0.6, 1.0);"
+        ]),
+        "parameters": [{"name": "Intensity", "kind": "Scalar"}],
+        "outputs": ["Roughness", "Metallic", "Normal"]
+    })
+    await call(conn, "hlsl_compile")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_demo())

--- a/Resources/Python/APITest/Material_Protocol_Static_Check.py
+++ b/Resources/Python/APITest/Material_Protocol_Static_Check.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def require_text(path: str, needle: str) -> None:
+    text = (ROOT / path).read_text(encoding="utf-8")
+    if needle not in text:
+        raise AssertionError(f"{needle!r} not found in {path}")
+
+
+def main() -> None:
+    prompts = json.loads((ROOT / "Resources/prompts.json").read_text(encoding="utf-8"))
+    tools = {tool["name"]: tool for tool in prompts.get("tools", [])}
+    enabled_tool_names = {name for name, tool in tools.items() if tool.get("enabled", True)}
+    material_mode = json.loads((ROOT / "Resources/ToolModes/Material.json").read_text(encoding="utf-8"))
+    allowed_tools = set(material_mode.get("allowed_tools", []))
+
+    required_tools = {
+        "hlsl_set_target",
+        "hlsl_get",
+        "hlsl_set",
+        "hlsl_delete",
+        "hlsl_compile",
+    }
+
+    disabled_aliases = {
+        "material_modify_type",
+        "hlsl_delete_parameter",
+        "hlsl_delete_output",
+    }
+
+    missing_prompts = required_tools - enabled_tool_names
+    missing_mode = required_tools - allowed_tools
+    if missing_prompts:
+        raise AssertionError(f"Missing prompts tools: {sorted(missing_prompts)}")
+    if missing_mode:
+        raise AssertionError(f"Missing Material mode tools: {sorted(missing_mode)}")
+    for alias in disabled_aliases:
+        if tools.get(alias, {}).get("enabled", True):
+            raise AssertionError(f"Compatibility alias should be disabled in prompts: {alias}")
+        if alias in allowed_tools:
+            raise AssertionError(f"Compatibility alias should not be in Material mode: {alias}")
+
+    require_text("Source/UmgMcp/Private/Material/UmgMcpMaterialCommands.cpp", "CommandType == TEXT(\"hlsl_delete\")")
+    require_text("Source/UmgMcp/Private/Material/UmgMcpMaterialCommands.cpp", "HasMaterialTypeOptions")
+    require_text("Source/UmgMcp/Private/Material/UmgMcpMaterialCommands.cpp", "ApplyHlslOutputs")
+    require_text("Source/UmgMcp/Private/Material/UmgMcpMaterialCommands.cpp", "AdditionalOutputs")
+    require_text("Source/UmgMcp/Private/Material/UmgMcpMaterialSubsystem.cpp", "ResolveExpressionOutputIndex")
+    require_text("Resources/Python/UmgMcpServer.py", "async def hlsl_delete")
+    require_text("Resources/Python/Material/UMGMaterial.py", "async def hlsl_delete")
+    require_text("Document/MaterialMcpProtocol.md", "outputs")
+
+    print("Material protocol static check passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Resources/Python/Material/UMGMaterial.py
+++ b/Resources/Python/Material/UMGMaterial.py
@@ -5,7 +5,7 @@ logger = logging.getLogger("UmgMcpServer")
 
 class UMGMaterial:
     """
-    Client for the 'Material' category of commands (5 Pillars API).
+    Client for the 'Material' category of commands.
     """
     def __init__(self, connection):
         self.connection = connection
@@ -16,6 +16,28 @@ class UMGMaterial:
         # We can still pass it if we want, but user asked to simplify.
         # Let's just pass path.
         return await self.connection.send_command("material_set_target", params)
+
+    async def modify_type(
+        self,
+        path: Optional[str] = None,
+        domain: Optional[str] = None,
+        blend_mode: Optional[str] = None,
+        shading_model: Optional[str] = None,
+        two_sided: Optional[bool] = None,
+        refresh_hlsl_wiring: bool = True
+    ) -> dict:
+        params: Dict[str, Any] = {"refresh_hlsl_wiring": refresh_hlsl_wiring}
+        if path:
+            params["path"] = path
+        if domain is not None:
+            params["domain"] = domain
+        if blend_mode is not None:
+            params["blend_mode"] = blend_mode
+        if shading_model is not None:
+            params["shading_model"] = shading_model
+        if two_sided is not None:
+            params["two_sided"] = two_sided
+        return await self.connection.send_command("material_modify_type", params)
 
     async def define_variable(self, name: str, type: str) -> dict:
         return await self.connection.send_command("material_define_variable", {"name": name, "type": type})
@@ -75,23 +97,69 @@ class UMGMaterial:
     # ------------------------------
     # HLSL streamlined protocol
     # ------------------------------
-    async def hlsl_set_target(self, path: str, confirm_overwrite: bool = False, create_if_not_found: bool = True) -> dict:
-        return await self.connection.send_command("hlsl_set_target", {
+    async def hlsl_set_target(
+        self,
+        path: str,
+        confirm_overwrite: bool = False,
+        create_if_not_found: bool = True,
+        domain: Optional[str] = None,
+        blend_mode: Optional[str] = None,
+        shading_model: Optional[str] = None,
+        two_sided: Optional[bool] = None
+    ) -> dict:
+        params: Dict[str, Any] = {
             "path": path,
             "confirm_overwrite": confirm_overwrite,
             "create_if_not_found": create_if_not_found
-        })
+        }
+        if domain is not None:
+            params["domain"] = domain
+        if blend_mode is not None:
+            params["blend_mode"] = blend_mode
+        if shading_model is not None:
+            params["shading_model"] = shading_model
+        if two_sided is not None:
+            params["two_sided"] = two_sided
+        return await self.connection.send_command("hlsl_set_target", params)
 
     async def hlsl_get(self) -> dict:
         return await self.connection.send_command("hlsl_get", {})
 
-    async def hlsl_set(self, hlsl: Optional[str] = None, parameters: Optional[List[Dict[str, Any]]] = None) -> dict:
+    async def hlsl_set(
+        self,
+        hlsl: Optional[str] = None,
+        parameters: Optional[List[Dict[str, Any]]] = None,
+        outputs: Optional[List[Any]] = None
+    ) -> dict:
         params: Dict[str, Any] = {}
         if hlsl is not None:
             params["hlsl"] = hlsl
         if parameters is not None:
             params["parameters"] = parameters
+        if outputs is not None:
+            params["outputs"] = outputs
         return await self.connection.send_command("hlsl_set", params)
+
+    async def hlsl_delete_parameter(self, names: List[str], confirm_delete: bool = False) -> dict:
+        return await self.connection.send_command("hlsl_delete_parameter", {
+            "names": names,
+            "confirm_delete": confirm_delete
+        })
+
+    async def hlsl_delete(self, names: List[str], confirm_delete: bool = False, kind: Optional[str] = None) -> dict:
+        params: Dict[str, Any] = {
+            "names": names,
+            "confirm_delete": confirm_delete
+        }
+        if kind is not None:
+            params["kind"] = kind
+        return await self.connection.send_command("hlsl_delete", params)
+
+    async def hlsl_delete_output(self, names: List[str], confirm_delete: bool = False) -> dict:
+        return await self.connection.send_command("hlsl_delete_output", {
+            "names": names,
+            "confirm_delete": confirm_delete
+        })
 
     async def hlsl_compile(self) -> dict:
         return await self.connection.send_command("hlsl_compile", {})

--- a/Resources/Python/UmgMcpServer.py
+++ b/Resources/Python/UmgMcpServer.py
@@ -308,7 +308,7 @@ async def get_creatable_widget_types() -> Dict[str, Any]:
     (Description loaded from prompts.json)
     """
     # Per user instruction, return a philosophical guide instead of a fixed list.
-    # This encourages the AI to experiment based on its own knowledge.
+    # This encourages the AI to experiment based on its knowledge.
     return {
         "status": "success",
         "result": {
@@ -1036,7 +1036,7 @@ async def animation_delete_widget_keys(property_name: str, times: List[float], w
 
 
 # =============================================================================
-#  Category: Material (New - 5 Pillars API)
+#  Category: Material
 # =============================================================================
 
 @register_tool("material_set_target", "Specify target asset (path or parent). Required for stateful editing.")
@@ -1047,6 +1047,22 @@ async def material_set_target(path: str, create_if_not_found: bool = True) -> Di
     conn = get_unreal_connection()
     material_client = UMGMaterial.UMGMaterial(conn)
     return await material_client.set_target_material(path, create_if_not_found)
+
+@register_tool("material_modify_type", "Modify the active material type for non-UMG materials.")
+async def material_modify_type(
+    path: Optional[str] = None,
+    domain: Optional[str] = None,
+    blend_mode: Optional[str] = None,
+    shading_model: Optional[str] = None,
+    two_sided: Optional[bool] = None,
+    refresh_hlsl_wiring: bool = True
+) -> Dict[str, Any]:
+    """
+    (Description loaded from prompts.json)
+    """
+    conn = get_unreal_connection()
+    material_client = UMGMaterial.UMGMaterial(conn)
+    return await material_client.modify_type(path, domain, blend_mode, shading_model, two_sided, refresh_hlsl_wiring)
 
 @register_tool("material_define_variable", "Define external interface parameters (Scalar, Vector, Texture).")
 async def material_define_variable(name: str, type: str) -> Dict[str, Any]:
@@ -1140,13 +1156,21 @@ async def material_get_graph() -> Dict[str, Any]:
 
 
 @register_tool("hlsl_set_target", "Set HLSL editing target material; supports create/overwrite flow.")
-async def hlsl_set_target(path: str, confirm_overwrite: bool = False, create_if_not_found: bool = True) -> Dict[str, Any]:
+async def hlsl_set_target(
+    path: str,
+    confirm_overwrite: bool = False,
+    create_if_not_found: bool = True,
+    domain: Optional[str] = None,
+    blend_mode: Optional[str] = None,
+    shading_model: Optional[str] = None,
+    two_sided: Optional[bool] = None
+) -> Dict[str, Any]:
     """
     (Description loaded from prompts.json)
     """
     conn = get_unreal_connection()
     material_client = UMGMaterial.UMGMaterial(conn)
-    return await material_client.hlsl_set_target(path, confirm_overwrite, create_if_not_found)
+    return await material_client.hlsl_set_target(path, confirm_overwrite, create_if_not_found, domain, blend_mode, shading_model, two_sided)
 
 
 @register_tool("hlsl_get", "Read current HLSL code and parameter definitions.")
@@ -1159,14 +1183,48 @@ async def hlsl_get() -> Dict[str, Any]:
     return await material_client.hlsl_get()
 
 
-@register_tool("hlsl_set", "Incrementally update HLSL code and/or parameter list with explicit delete semantics.")
-async def hlsl_set(hlsl: Optional[str] = None, parameters: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+@register_tool("hlsl_set", "Incrementally apply HLSL code, parameters, and/or outputs; union-only, no deletion.")
+async def hlsl_set(
+    hlsl: Optional[str] = None,
+    parameters: Optional[List[Dict[str, Any]]] = None,
+    outputs: Optional[List[Any]] = None
+) -> Dict[str, Any]:
     """
     (Description loaded from prompts.json)
     """
     conn = get_unreal_connection()
     material_client = UMGMaterial.UMGMaterial(conn)
-    return await material_client.hlsl_set(hlsl, parameters)
+    return await material_client.hlsl_set(hlsl, parameters, outputs)
+
+
+@register_tool("hlsl_delete_parameter", "Explicitly delete HLSL parameters from the active HLSL material target.")
+async def hlsl_delete_parameter(names: List[str], confirm_delete: bool = False) -> Dict[str, Any]:
+    """
+    (Description loaded from prompts.json)
+    """
+    conn = get_unreal_connection()
+    material_client = UMGMaterial.UMGMaterial(conn)
+    return await material_client.hlsl_delete_parameter(names, confirm_delete)
+
+
+@register_tool("hlsl_delete", "Explicitly delete HLSL parameters or outputs from the active HLSL material target.")
+async def hlsl_delete(names: List[str], confirm_delete: bool = False, kind: Optional[str] = None) -> Dict[str, Any]:
+    """
+    (Description loaded from prompts.json)
+    """
+    conn = get_unreal_connection()
+    material_client = UMGMaterial.UMGMaterial(conn)
+    return await material_client.hlsl_delete(names, confirm_delete, kind)
+
+
+@register_tool("hlsl_delete_output", "Explicitly delete HLSL outputs from the active HLSL material target.")
+async def hlsl_delete_output(names: List[str], confirm_delete: bool = False) -> Dict[str, Any]:
+    """
+    (Description loaded from prompts.json)
+    """
+    conn = get_unreal_connection()
+    material_client = UMGMaterial.UMGMaterial(conn)
+    return await material_client.hlsl_delete_output(names, confirm_delete)
 
 
 @register_tool("hlsl_compile", "Compile current HLSL material target and return concise diagnostics.")

--- a/Resources/ToolModes/Material.json
+++ b/Resources/ToolModes/Material.json
@@ -1,0 +1,10 @@
+{
+    "allowed_tools": [
+        "hlsl_set_target",
+        "hlsl_get",
+        "hlsl_set",
+        "hlsl_delete",
+        "hlsl_compile"
+    ],
+    "system_instruction": "你是一位虚幻引擎材质专家。默认创建 UI 材质；如果需求不是 UMG/UI 材质，在 hlsl_set_target 中携带 domain/blend_mode/shading_model/two_sided。主要使用 hlsl_set_target / hlsl_get / hlsl_set / hlsl_delete / hlsl_compile；hlsl_set 可并集覆盖和追加 hlsl/parameters/outputs，但不能删除；删除用 hlsl_delete(names, confirm_delete=true)，只有名称歧义时再追加 kind='parameter' 或 kind='output'。outputs 用于 Roughness/Metallic/Normal 等材质根输出，避免传统 material_* 图编辑工具。"
+}

--- a/Resources/prompts.json
+++ b/Resources/prompts.json
@@ -1,5 +1,5 @@
 {
-    "system_instruction": "You are an expert Unreal Engine UMG assistant. \n\n### CORE CONCEPT: THE 'ACTIVE TARGET'\nYour work revolves around an **'Active Target'**\u2014the specific UMG Widget Blueprint you are currently editing. \n\n### GLOBAL TOOL BEHAVIOR\n**Unless explicitly stated otherwise**, all tools in the 'UMG' and 'Animation' categories implicitly operate on this **Active Target**. You DO NOT need to provide the 'asset_path' argument if the target is already set.\n\n### DEFAULT OPERATION MECHANISM\nThe system determines the **Active Target** using a 4-level Fallback Priority:\n1. **Explicit Parameter**: 'asset_path' provided in the tool call.\n2. **Cached Target**: Set via 'set_target_umg_asset'.\n3. **Editor Focus**: The currently focused asset in the UE Editor.\n4. **History**: The last edited asset.\n\n### WORKFLOW PROTOCOL\n1. **Establish Context**: Start by setting the **Active Target** (`set_target_umg_asset`) and optionally the **Active Widget** (`set_active_widget`).\n2. **Discover Assets**: When setting properties that require an asset (Texture, Material, etc.), you MUST use `list_assets` to valid paths. Do not guess paths.\n3. **Implicit Parenting**: `create_widget` automatically attaches to the **Active Widget** if no parent is specified. This enables fluent, breadth-first or depth-first tree construction.\n4. **Modify**: Issue commands like `create_widget` or `set_widget_properties` without repeating paths or parents if context is set.\n5. **Animation**: Use `set_animation_data` for complex, multi-track animations. Supported property types include Float (e.g., `RenderOpacity`), Vector2D (e.g., `RenderTransform.Translation`, `RenderTransform.Scale`), and LinearColor (e.g., `ColorAndOpacity`).\n\n### IMPORTANT: CREATING WIDGETS\n- **Implicit Parent**: If you omit `parent_name`, the system uses the **Active Widget** (set via `set_active_widget`).\n- **Root Fallback**: If no Active Widget is set, it defaults to the **Root Widget**.\n- **Empty Tree**: If the tree is empty, the first widget MUST be a Panel (e.g. CanvasPanel) and becomes Root.\n- **Widget Prefer**: Autosize Widget is good, like Vertical Box. Don't use CanvasPanel since it isn't autosize\n\n### BLUEPRINT EDITING WORKFLOW\n1. **Set Target**: Use `set_edit_function` to focus on a specific Function or Graph (e.g., 'EventGraph', 'MyFunction').\n2. **Add Logic**: Use `add_function_step` to append logic nodes to the **Active function**. The system automatically handles wiring to the 'Cursor Node'.\n3. **prepare date**: for those couldn't run node,Use `prepare_data` to place it and use `connect` to set.\n4. **Compile**: Use `compile_blueprint` (no args) to apply changes.\n\n### MATERIAL EDITING WORKFLOW (The 5 Pillars)\n1. **Set Target**: Use `material_set_target` to specify the asset.\n2. **Define Interface**: Use `material_define_variable` for Scalar/Vector/Texture parameters.\n3. **Add Nodes**: Use `material_add_node` to place Expressions (e.g. 'Add', 'Multiply', 'TextureSample').\n4. **Connect Logic**: \n   - **Natural**: `material_connect_nodes(A, B)` for simple flow.\n   - **Surgical**: `material_connect_pins(A, Pin, B, Pin)` for specific wiring.\n   - **Output**: Connect the final node to 'Master' or 'Output' to see results.\n5. **Tactical Code**: Use `material_set_hlsl_node_io` to inject HLSL into Custom nodes.\n6. **Apply**: Use `material_compile_asset` to save and update the material shader.\n\n### HLSL TEXT-EDIT WORKFLOW (Recommended for UMG)\n1. **Set Target**: `hlsl_set_target(path)` to lock/create a UI material with single Custom HLSL topology.\n2. **Read**: `hlsl_get()` to retrieve current HLSL code + structured parameters.\n3. **Write Incrementally**: `hlsl_set(hlsl=?, parameters=?)`.\n   - Sending only `hlsl` updates code without changing parameters.\n   - Sending only `parameters` updates parameter wiring without changing code.\n   - Deletion is explicit: include `{ \"name\": \"Param\", \"delete\": true }`.\n4. **Compile**: `hlsl_compile()` to get concise compile diagnostics.\n5. **Output Contract**: Return value is treated as `float4`; backend auto-wires `.rgb -> FinalColor`, `.a -> Opacity`.\n\n### HANDLING EVENTS (INTERACTION)\nTo make UI interactive (e.g., Button Clicks):\n1. **Bind Event**: Use `set_edit_function` with 'WidgetName.EventName' syntax.\n   - Example: `set_edit_function('MyButton.OnClicked')`.\n   - This automatically creates the event node in the EventGraph and focuses it.\n2. **Add Logic**: Simply add steps. The cursor is already set to the event.\n   - Example: `add_function_step('PrintString', args=['Clicked!'])`.",
+    "system_instruction": "You are an expert Unreal Engine UMG assistant. \n\n### CORE CONCEPT: THE 'ACTIVE TARGET'\nYour work revolves around an **'Active Target'**—the specific UMG Widget Blueprint you are currently editing. \n\n### GLOBAL TOOL BEHAVIOR\n**Unless explicitly stated otherwise**, all tools in the 'UMG' and 'Animation' categories implicitly operate on this **Active Target**. You DO NOT need to provide the 'asset_path' argument if the target is already set.\n\n### DEFAULT OPERATION MECHANISM\nThe system determines the **Active Target** using a 4-level Fallback Priority:\n1. **Explicit Parameter**: 'asset_path' provided in the tool call.\n2. **Cached Target**: Set via 'set_target_umg_asset'.\n3. **Editor Focus**: The currently focused asset in the UE Editor.\n4. **History**: The last edited asset.\n\n### WORKFLOW PROTOCOL\n1. **Establish Context**: Start by setting the **Active Target** (`set_target_umg_asset`) and optionally the **Active Widget** (`set_active_widget`).\n2. **Discover Assets**: When setting properties that require an asset (Texture, Material, etc.), you MUST use `list_assets` to valid paths. Do not guess paths.\n3. **Implicit Parenting**: `create_widget` automatically attaches to the **Active Widget** if no parent is specified. This enables fluent, breadth-first or depth-first tree construction.\n4. **Modify**: Issue commands like `create_widget` or `set_widget_properties` without repeating paths or parents if context is set.\n5. **Animation**: Use `set_animation_data` for complex, multi-track animations. Supported property types include Float (e.g., `RenderOpacity`), Vector2D (e.g., `RenderTransform.Translation`, `RenderTransform.Scale`), and LinearColor (e.g., `ColorAndOpacity`).\n\n### IMPORTANT: CREATING WIDGETS\n- **Implicit Parent**: If you omit `parent_name`, the system uses the **Active Widget** (set via `set_active_widget`).\n- **Root Fallback**: If no Active Widget is set, it defaults to the **Root Widget**.\n- **Empty Tree**: If the tree is empty, the first widget MUST be a Panel (e.g. CanvasPanel) and becomes Root.\n- **Widget Prefer**: Autosize Widget is good, like Vertical Box. Don't use CanvasPanel since it isn't autosize\n\n### BLUEPRINT EDITING WORKFLOW\n1. **Set Target**: Use `set_edit_function` to focus on a specific Function or Graph (e.g., 'EventGraph', 'MyFunction').\n2. **Add Logic**: Use `add_function_step` to append logic nodes to the **Active function**. The system automatically handles wiring to the 'Cursor Node'.\n3. **prepare date**: for those couldn't run node,Use `prepare_data` to place it and use `connect` to set.\n4. **Compile**: Use `compile_blueprint` (no args) to apply changes.\n\n### MATERIAL EDITING WORKFLOW\nUse the HLSL text-edit workflow below as the primary material path. Legacy `material_*` graph tools are fallback-only for operations that cannot be represented by one HLSL Custom node, parameters, outputs, delete, and compile.\n\n### HLSL TEXT-EDIT WORKFLOW (Default UI, supports explicit non-UI type)\n1. **Set Target**: `hlsl_set_target(path, domain=?, blend_mode=?, shading_model=?, two_sided=?)` locks/creates a material with single Custom HLSL topology. New targets default to UI material; optional type fields switch non-UI material type during target setup.\n2. **Read**: `hlsl_get()` to retrieve current HLSL code + structured parameters.\n3. **Write Incrementally**: `hlsl_set(hlsl=?, parameters=?, outputs=?)`.\n   - Sending only `hlsl` updates code without changing parameters or outputs.\n   - Sending only `parameters` updates/adds parameter wiring without changing code.\n   - Sending only `outputs` updates/adds Custom additional outputs and material root wiring.\n   - `hlsl_set` is union-only and never deletes; use `hlsl_delete(names, confirm_delete=true, kind=?)` for deletion. Omit kind unless a name is ambiguous.\n4. **Compile**: `hlsl_compile()` to get concise compile diagnostics.\n5. **Output Contract**: Return value is treated as `float4`; backend returns `output_contract` describing whether rgb/a map to EmissiveColor, BaseColor, Opacity, OpacityMask, plus any additional material outputs.\n\n### HANDLING EVENTS (INTERACTION)\nTo make UI interactive (e.g., Button Clicks):\n1. **Bind Event**: Use `set_edit_function` with 'WidgetName.EventName' syntax.\n   - Example: `set_edit_function('MyButton.OnClicked')`.\n   - This automatically creates the event node in the EventGraph and focuses it.\n2. **Add Logic**: Simply add steps. The cursor is already set to the event.\n   - Example: `add_function_step('PrintString', args=['Clicked!'])`.",
     "tools": [
         {
             "name": "get_widget_schema",
@@ -16,6 +16,12 @@
         {
             "name": "get_target_umg_asset",
             "description": "Gets the current **Active Target** path. Use this to confirm context.",
+            "enabled": true,
+            "category": "UMG"
+        },
+        {
+            "name": "get_target_widget",
+            "description": "Gets the current focused widget target in the active UMG asset.",
             "enabled": true,
             "category": "UMG"
         },
@@ -272,6 +278,12 @@
             "category": "Material"
         },
         {
+            "name": "material_modify_type",
+            "description": "Compatibility alias. Prefer hlsl_set_target(..., domain/blend_mode/shading_model/two_sided) for material type changes.",
+            "enabled": false,
+            "category": "Material"
+        },
+        {
             "name": "material_define_variable",
             "description": "Define external interface parameters (Scalar, Vector, Texture).",
             "enabled": true,
@@ -333,7 +345,7 @@
         },
         {
             "name": "hlsl_set_target",
-            "description": "Set/create/overwrite HLSL editing target. Requires UI material with single Custom node.",
+            "description": "Set/create/overwrite HLSL editing target. New targets default to UI material. Optional domain/blend_mode/shading_model/two_sided fields change material type during target setup.",
             "enabled": true,
             "category": "Material"
         },
@@ -345,7 +357,25 @@
         },
         {
             "name": "hlsl_set",
-            "description": "Incrementally update HLSL code and/or parameters. Deletion requires explicit delete marker.",
+            "description": "Incrementally apply HLSL code, parameters, and/or outputs. Union-only: updates existing entries and appends missing ones; it never deletes. outputs can be strings like 'Roughness' or objects like {name,target,type}.",
+            "enabled": true,
+            "category": "Material"
+        },
+        {
+            "name": "hlsl_delete_parameter",
+            "description": "Compatibility alias. Prefer hlsl_delete(names, confirm_delete=true, kind='parameter').",
+            "enabled": false,
+            "category": "Material"
+        },
+        {
+            "name": "hlsl_delete_output",
+            "description": "Compatibility alias. Prefer hlsl_delete(names, confirm_delete=true, kind='output').",
+            "enabled": false,
+            "category": "Material"
+        },
+        {
+            "name": "hlsl_delete",
+            "description": "Explicitly delete HLSL parameters or outputs by semantic name. Requires confirm_delete=true. If name is ambiguous, retry with kind='parameter' or kind='output'.",
             "enabled": true,
             "category": "Material"
         },

--- a/Skills/umg-material-mcp/SKILL.md
+++ b/Skills/umg-material-mcp/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: umg-material-mcp
+description: Use when Codex needs to create, inspect, edit, delete, or validate UE5.8 material assets through Unreal Motion Graphics MCP/FabUmgMcp HLSL material tools, especially one-HLSL Custom-node authoring, UI-default versus non-UI material type selection, union-only writes, semantic outputs, hlsl_delete recovery, or Material ToolMode protocol work.
+---
+
+# UMG Material MCP
+
+Use the Material HLSL MCP path for material authoring. Do not mutate `.uasset` files directly. Keep Unreal Editor open with the UMG MCP bridge listening before runtime tool calls.
+
+For concrete command examples and regression cases, read [demo-cases.md](references/demo-cases.md).
+
+## Primary Workflow
+
+1. Set or create the HLSL target with `hlsl_set_target`.
+   - New targets default to UI material behavior.
+   - For non-UI materials, pass type fields directly on `hlsl_set_target`: `domain`, `blend_mode`, `shading_model`, `two_sided`.
+   - Prefer this over `material_modify_type`; that command is compatibility-only.
+
+2. Read with `hlsl_get`.
+   - Treat the response as semantic state: HLSL text, parameter snapshot, and `output_contract`.
+   - Do not request or reconstruct full material graphs unless the HLSL protocol cannot express the task.
+
+3. Write with `hlsl_set(hlsl?, parameters?, outputs?)`.
+   - `hlsl_set` is union-only: update existing entries and append missing entries.
+   - It must not delete parameters or outputs.
+   - Use `parameters` for Custom node inputs such as `{"name":"Intensity","kind":"Scalar"}`.
+   - Use `outputs` for root material outputs such as `"Roughness"`, `"Metallic"`, `"Normal"`, or objects with `name`, `target`, and `type`.
+   - Additional outputs are UE5.8 Custom node `AdditionalOutputs`; assign same-name variables in HLSL, for example `Roughness = 0.35;`.
+
+4. Delete with `hlsl_delete(names, confirm_delete=true, kind?)`.
+   - Omit `kind` in the normal path.
+   - If a name matches both parameter and output, expect failure with `requires_kind: true`; retry with `kind="parameter"` or `kind="output"`.
+   - Do not use `hlsl_delete_parameter` or `hlsl_delete_output` in primary flows; they are compatibility aliases.
+
+5. Compile with `hlsl_compile`.
+   - Treat compile diagnostics as the feedback loop.
+   - Prefer small repair writes with `hlsl_set(hlsl=...)` rather than resetting the target.
+
+## Protocol Rules
+
+- The material is represented as one HLSL program on a single Custom node.
+- The Custom node primary return is `float4`.
+- `output_contract` describes where rgb/a and any additional outputs are wired.
+- UI, PostProcess, LightFunction, and Unlit output rgb to `EmissiveColor`; lit Surface output rgb usually maps to `BaseColor`.
+- Alpha maps only when semantically useful: UI/translucent to `Opacity`, masked to `OpacityMask`.
+- Do not fall back to legacy `material_*` graph editing unless the requested operation cannot be modeled by HLSL target, parameters, outputs, delete, and compile.
+
+## Validation
+
+Use the narrowest relevant checks:
+
+```powershell
+python -m py_compile Resources\Python\UmgMcpServer.py Resources\Python\Material\UMGMaterial.py Resources\Python\APITest\Material_HLSL_Type_Demo.py Resources\Python\APITest\Material_Protocol_Static_Check.py
+python Resources\Python\APITest\Material_Protocol_Static_Check.py
+& 'D:\UE_5.8\Engine\Build\BatchFiles\Build.bat' FabUMGMCPEditor Win64 Development -Project='D:\UE5Project\FabUMGMCP\FabUMGMCP.uproject' -NoHotReloadFromIDE -Progress
+python Resources\Python\APITest\Material_HLSL_Type_Demo.py
+```
+
+The runtime demo requires Unreal Editor to be open and the MCP socket in `Resources/Python/mcp_config.py` to be reachable.

--- a/Skills/umg-material-mcp/agents/openai.yaml
+++ b/Skills/umg-material-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UMG Material MCP"
+  short_description: "Author UE5.8 materials through UMG MCP HLSL tools."
+  default_prompt: "Use this skill when editing Unreal materials through the UMG MCP HLSL protocol."

--- a/Skills/umg-material-mcp/references/demo-cases.md
+++ b/Skills/umg-material-mcp/references/demo-cases.md
@@ -1,0 +1,127 @@
+# Material HLSL MCP Demo Cases
+
+Use these cases as examples when authoring or validating material MCP changes.
+
+## Case 1: Default UI Material
+
+Create or lock a UI material target without type fields:
+
+```python
+await hlsl_set_target(
+    path="/Game/UMGMCP/Demos/M_Hlsl_UI",
+    create_if_not_found=True
+)
+await hlsl_set(
+    hlsl="return float4(UV.x, UV.y, 1.0, 0.85);",
+    parameters=[]
+)
+await hlsl_compile()
+```
+
+Expected contract:
+
+```json
+{
+  "return": "float4",
+  "domain": "ui",
+  "blend_mode": "translucent",
+  "shading_model": "unlit",
+  "rgb_to": "EmissiveColor",
+  "a_to": "Opacity"
+}
+```
+
+## Case 2: Non-UI Surface Material
+
+Set material type on `hlsl_set_target`; do not call a separate type command:
+
+```python
+await hlsl_set_target(
+    path="/Game/UMGMCP/Demos/M_Hlsl_Surface",
+    create_if_not_found=True,
+    domain="surface",
+    shading_model="unlit",
+    blend_mode="opaque"
+)
+await hlsl_set(
+    hlsl="\n".join([
+        "float glow = saturate(Intensity);",
+        "Roughness = 0.28;",
+        "Metallic = 0.0;",
+        "Normal = normalize(float3(0.0, 0.0, 1.0));",
+        "return float4((0.05 + UV.x * 0.7) * glow, 0.2, 1.0 - UV.y * 0.6, 1.0);"
+    ]),
+    parameters=[{"name": "Intensity", "kind": "Scalar"}],
+    outputs=["Roughness", "Metallic", "Normal"]
+)
+await hlsl_compile()
+```
+
+Expected contract includes:
+
+```json
+{
+  "domain": "surface",
+  "blend_mode": "opaque",
+  "shading_model": "unlit",
+  "rgb_to": "EmissiveColor",
+  "outputs": [
+    {"name": "Roughness", "target": "Roughness", "connected": true},
+    {"name": "Metallic", "target": "Metallic", "connected": true},
+    {"name": "Normal", "target": "Normal", "connected": true}
+  ]
+}
+```
+
+## Case 3: Unified Delete Ambiguity
+
+If a parameter and output share the same semantic name, call `hlsl_delete` without `kind` first:
+
+```python
+await hlsl_set(
+    parameters=[{"name": "Roughness", "kind": "Scalar"}],
+    outputs=["Roughness", "Metallic", "Normal"]
+)
+result = await hlsl_delete(names=["Roughness"], confirm_delete=True)
+```
+
+Expected failure:
+
+```json
+{
+  "status": "error",
+  "requires_kind": true,
+  "ambiguous": [
+    {
+      "name": "Roughness",
+      "candidates": [
+        {"kind": "parameter", "name": "Roughness"},
+        {"kind": "output", "name": "Roughness"}
+      ]
+    }
+  ]
+}
+```
+
+Then retry precisely:
+
+```python
+await hlsl_delete(names=["Roughness"], kind="parameter", confirm_delete=True)
+await hlsl_delete(names=["Roughness"], kind="output", confirm_delete=True)
+```
+
+After deleting one output, remaining outputs must keep their own targets and `connected: true`; this guards against UE Custom-node AdditionalOutput index drift.
+
+## Repo Tests
+
+The runnable demo is:
+
+```powershell
+python Resources\Python\APITest\Material_HLSL_Type_Demo.py
+```
+
+The protocol shape/static regression is:
+
+```powershell
+python Resources\Python\APITest\Material_Protocol_Static_Check.py
+```

--- a/Source/UmgMcp/Private/Animation/UmgMcpSequencerCommands.cpp
+++ b/Source/UmgMcp/Private/Animation/UmgMcpSequencerCommands.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "Animation/UmgMcpSequencerCommands.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "Bridge/UmgMcpCommonUtils.h"
 #include "UmgMcp.h"
 #include "WidgetBlueprint.h"
@@ -1307,7 +1308,7 @@ TSharedPtr<FJsonObject> FUmgMcpSequencerCommands::AppendTimeSlice(const TSharedP
         int32 WidgetKeys = 0;
         for (const auto& PropertyPair : PropertiesObj->Values)
         {
-            FString PropertyName = PropertyPair.Key;
+            FString PropertyName = UmgMcpJsonCompat::KeyToString(PropertyPair.Key);
             TSharedPtr<FJsonObject> KeyObj = MakeShared<FJsonObject>();
             KeyObj->SetNumberField(TEXT("time"), TimeSeconds);
             KeyObj->SetField(TEXT("value"), PropertyPair.Value);

--- a/Source/UmgMcp/Private/Bridge/UmgMcpBridge.cpp
+++ b/Source/UmgMcp/Private/Bridge/UmgMcpBridge.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "Bridge/UmgMcpBridge.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "Bridge/UmgMcpConfig.h"
 #include "UmgMcp.h"
 #include "Bridge/MCPServerRunnable.h"
@@ -242,7 +243,7 @@ FString UUmgMcpBridge::ExecuteCommand(const FString& CommandType, const TSharedP
 {
     UE_LOG(LogUmgMcp, Display, TEXT("UmgMcpBridge: Received command: %s"), *CommandType);
     
-    // If we are already on the GameThread (e.g. called from FabServer or test), execute directly
+    // If we are already on the GameThread (e.g. internal call or test), execute directly
     if (IsInGameThread())
     {
         UE_LOG(LogUmgMcp, Verbose, TEXT("UmgMcpBridge: Already on GameThread, executing directly."));
@@ -490,7 +491,7 @@ FString UUmgMcpBridge::InternalExecuteCommand(const FString& CommandType, const 
         {
             ResultJson = BlueprintCommands->HandleCommand(CommandType, Params);
         }
-        // Material Commands (New 5 Pillars)
+        // Material commands
         else if (CommandType.StartsWith(TEXT("material_")) || CommandType.StartsWith(TEXT("hlsl_")))
         {
              ResultJson = MaterialCommands->HandleCommand(CommandType, Params);
@@ -522,7 +523,7 @@ FString UUmgMcpBridge::InternalExecuteCommand(const FString& CommandType, const 
                          // Copy existing fields
                          for (auto& Elem : Params->Values)
                          {
-                             ModifiedParams->SetField(Elem.Key, Elem.Value);
+                             ModifiedParams->SetField(UmgMcpJsonCompat::KeyToString(Elem.Key), Elem.Value);
                          }
 
                          FString SubAction;
@@ -681,7 +682,7 @@ FString UUmgMcpBridge::InternalExecuteCommand(const FString& CommandType, const 
             ResponseJson->SetStringField(TEXT("status"), TEXT("success"));
             for (const auto& Field : ResultJson->Values)
             {
-                const FString& Key = Field.Key;
+                const FString Key = UmgMcpJsonCompat::KeyToString(Field.Key);
                 if (Key != TEXT("success") && Key != TEXT("status"))
                 {
                     ResponseJson->SetField(Key, Field.Value);
@@ -690,9 +691,17 @@ FString UUmgMcpBridge::InternalExecuteCommand(const FString& CommandType, const 
         }
         else
         {
-            // Set error status and include the error message
+            // Preserve structured error metadata so clients can recover without reparsing text.
             ResponseJson->SetStringField(TEXT("status"), TEXT("error"));
             ResponseJson->SetStringField(TEXT("error"), ErrorMessage);
+            for (const auto& Field : ResultJson->Values)
+            {
+                const FString Key = UmgMcpJsonCompat::KeyToString(Field.Key);
+                if (Key != TEXT("success") && Key != TEXT("status") && Key != TEXT("error"))
+                {
+                    ResponseJson->SetField(Key, Field.Value);
+                }
+            }
         }
     }
     catch (const std::exception& e)

--- a/Source/UmgMcp/Private/Bridge/UmgMcpCommonUtils.cpp
+++ b/Source/UmgMcp/Private/Bridge/UmgMcpCommonUtils.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "Bridge/UmgMcpCommonUtils.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "GameFramework/Actor.h"
 #include "Engine/Blueprint.h"
 #include "EdGraph/EdGraph.h"
@@ -50,7 +51,7 @@ TSharedPtr<FJsonObject> FUmgMcpCommonUtils::CreateSuccessResponse(const TSharedP
         // Merge data fields directly instead of nesting under "data"
         for (const auto& Field : Data->Values)
         {
-            ResponseObject->SetField(Field.Key, Field.Value);
+            ResponseObject->SetField(UmgMcpJsonCompat::KeyToString(Field.Key), Field.Value);
         }
     }
     

--- a/Source/UmgMcp/Private/FileManage/UmgFileTransformation.cpp
+++ b/Source/UmgMcp/Private/FileManage/UmgFileTransformation.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "FileManage/UmgFileTransformation.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "UmgMcp.h"
 #include "PropertyNameMappings.h"
 #include "FileManage/UmgAttentionSubsystem.h"
@@ -76,7 +77,7 @@ TSharedPtr<FJsonObject> UUmgFileTransformation::NormalizeJsonKeysToPascalCase(co
     
     for (const auto& Pair : SourceJson->Values)
     {
-        FString OriginalKey = Pair.Key;
+        FString OriginalKey = UmgMcpJsonCompat::KeyToString(Pair.Key);
         FString NormalizedKey;
         
         // Handle dotted keys (e.g. "slot.position")
@@ -625,7 +626,8 @@ static void ApplyPropertiesToExistingWidget(const TSharedPtr<FJsonObject>& Widge
         TSharedPtr<FJsonObject> SourceProps = *PropertiesJsonObjPtr;
         for (auto& Pair : SourceProps->Values)
         {
-            if (Pair.Key == TEXT("Slot"))
+            const FString PropertyName = UmgMcpJsonCompat::KeyToString(Pair.Key);
+            if (PropertyName == TEXT("Slot"))
             {
                 const TSharedPtr<FJsonObject>* SlotObjPtr;
                 if (Pair.Value->TryGetObject(SlotObjPtr))
@@ -635,7 +637,7 @@ static void ApplyPropertiesToExistingWidget(const TSharedPtr<FJsonObject>& Widge
             }
             else
             {
-                WidgetProps->SetField(Pair.Key, Pair.Value);
+                WidgetProps->SetField(PropertyName, Pair.Value);
             }
         }
     }
@@ -810,7 +812,8 @@ static UWidget* CreateWidgetFromJson(const TSharedPtr<FJsonObject>& WidgetJson, 
         TSharedPtr<FJsonObject> SourceProps = *PropertiesJsonObjPtr;
         for (auto& Pair : SourceProps->Values)
         {
-            if (Pair.Key == TEXT("Slot"))
+            const FString PropertyName = UmgMcpJsonCompat::KeyToString(Pair.Key);
+            if (PropertyName == TEXT("Slot"))
             {
                 const TSharedPtr<FJsonObject>* SlotObjPtr;
                 if (Pair.Value->TryGetObject(SlotObjPtr))
@@ -820,7 +823,7 @@ static UWidget* CreateWidgetFromJson(const TSharedPtr<FJsonObject>& WidgetJson, 
             }
             else
             {
-                WidgetProps->SetField(Pair.Key, Pair.Value);
+                WidgetProps->SetField(PropertyName, Pair.Value);
             }
         }
     }

--- a/Source/UmgMcp/Private/Material/UmgMcpMaterialCommands.cpp
+++ b/Source/UmgMcp/Private/Material/UmgMcpMaterialCommands.cpp
@@ -21,8 +21,12 @@ namespace
     constexpr const TCHAR* UnknownParamKind = TEXT("Unknown");
     constexpr const TCHAR* DefaultParamKind = TEXT("Scalar");
     constexpr const TCHAR* MasterHandleName = TEXT("Master");
-    constexpr const TCHAR* FinalColorPinName = TEXT("FinalColor");
+    constexpr const TCHAR* EmissiveColorPinName = TEXT("EmissiveColor");
+    constexpr const TCHAR* BaseColorPinName = TEXT("BaseColor");
     constexpr const TCHAR* OpacityPinName = TEXT("Opacity");
+    constexpr const TCHAR* OpacityMaskPinName = TEXT("OpacityMask");
+    constexpr const TCHAR* HlslRgbDesc = TEXT("HLSL_RGB");
+    constexpr const TCHAR* HlslAlphaDesc = TEXT("HLSL_A");
 
     static bool IsErrorStatus(const FString& Status)
     {
@@ -89,6 +93,803 @@ namespace
         return FindInObject(Mat);
     }
 
+    static FString NormalizeMaterialToken(FString Value)
+    {
+        Value = Value.TrimStartAndEnd();
+        Value.ReplaceInline(TEXT(" "), TEXT(""));
+        Value.ReplaceInline(TEXT("-"), TEXT("_"));
+        Value.ReplaceInline(TEXT("."), TEXT("_"));
+        return Value.ToLower();
+    }
+
+    static bool ParseMaterialDomain(const FString& Input, EMaterialDomain& OutDomain)
+    {
+        const FString Key = NormalizeMaterialToken(Input);
+        if (Key == TEXT("ui") || Key == TEXT("umg") || Key == TEXT("userinterface") || Key == TEXT("user_interface") || Key == TEXT("md_ui"))
+        {
+            OutDomain = EMaterialDomain::MD_UI;
+            return true;
+        }
+        if (Key == TEXT("surface") || Key == TEXT("md_surface"))
+        {
+            OutDomain = EMaterialDomain::MD_Surface;
+            return true;
+        }
+        if (Key == TEXT("postprocess") || Key == TEXT("post_process") || Key == TEXT("md_postprocess"))
+        {
+            OutDomain = EMaterialDomain::MD_PostProcess;
+            return true;
+        }
+        if (Key == TEXT("decal") || Key == TEXT("deferreddecal") || Key == TEXT("deferred_decal") || Key == TEXT("md_deferreddecal"))
+        {
+            OutDomain = EMaterialDomain::MD_DeferredDecal;
+            return true;
+        }
+        if (Key == TEXT("lightfunction") || Key == TEXT("light_function") || Key == TEXT("md_lightfunction"))
+        {
+            OutDomain = EMaterialDomain::MD_LightFunction;
+            return true;
+        }
+        if (Key == TEXT("volume") || Key == TEXT("md_volume"))
+        {
+            OutDomain = EMaterialDomain::MD_Volume;
+            return true;
+        }
+        return false;
+    }
+
+    static bool ParseBlendMode(const FString& Input, EBlendMode& OutBlendMode)
+    {
+        const FString Key = NormalizeMaterialToken(Input);
+        if (Key == TEXT("opaque") || Key == TEXT("blend_opaque"))
+        {
+            OutBlendMode = BLEND_Opaque;
+            return true;
+        }
+        if (Key == TEXT("masked") || Key == TEXT("blend_masked"))
+        {
+            OutBlendMode = BLEND_Masked;
+            return true;
+        }
+        if (Key == TEXT("translucent") || Key == TEXT("blend_translucent"))
+        {
+            OutBlendMode = BLEND_Translucent;
+            return true;
+        }
+        if (Key == TEXT("additive") || Key == TEXT("blend_additive"))
+        {
+            OutBlendMode = BLEND_Additive;
+            return true;
+        }
+        if (Key == TEXT("modulate") || Key == TEXT("blend_modulate"))
+        {
+            OutBlendMode = BLEND_Modulate;
+            return true;
+        }
+        if (Key == TEXT("alphacomposite") || Key == TEXT("alpha_composite") || Key == TEXT("premultipliedalpha") || Key == TEXT("blend_alphacomposite"))
+        {
+            OutBlendMode = BLEND_AlphaComposite;
+            return true;
+        }
+        if (Key == TEXT("alphaholdout") || Key == TEXT("alpha_holdout") || Key == TEXT("blend_alphaholdout"))
+        {
+            OutBlendMode = BLEND_AlphaHoldout;
+            return true;
+        }
+        return false;
+    }
+
+    static bool ParseShadingModel(const FString& Input, EMaterialShadingModel& OutShadingModel)
+    {
+        const FString Key = NormalizeMaterialToken(Input);
+        if (Key == TEXT("unlit") || Key == TEXT("msm_unlit"))
+        {
+            OutShadingModel = MSM_Unlit;
+            return true;
+        }
+        if (Key == TEXT("defaultlit") || Key == TEXT("default_lit") || Key == TEXT("lit") || Key == TEXT("msm_defaultlit"))
+        {
+            OutShadingModel = MSM_DefaultLit;
+            return true;
+        }
+        if (Key == TEXT("subsurface") || Key == TEXT("msm_subsurface"))
+        {
+            OutShadingModel = MSM_Subsurface;
+            return true;
+        }
+        if (Key == TEXT("preintegratedskin") || Key == TEXT("preintegrated_skin") || Key == TEXT("msm_preintegratedskin"))
+        {
+            OutShadingModel = MSM_PreintegratedSkin;
+            return true;
+        }
+        if (Key == TEXT("clearcoat") || Key == TEXT("clear_coat") || Key == TEXT("msm_clearcoat"))
+        {
+            OutShadingModel = MSM_ClearCoat;
+            return true;
+        }
+        if (Key == TEXT("subsurfaceprofile") || Key == TEXT("subsurface_profile") || Key == TEXT("msm_subsurfaceprofile"))
+        {
+            OutShadingModel = MSM_SubsurfaceProfile;
+            return true;
+        }
+        if (Key == TEXT("twosidedfoliage") || Key == TEXT("two_sided_foliage") || Key == TEXT("msm_twosidedfoliage"))
+        {
+            OutShadingModel = MSM_TwoSidedFoliage;
+            return true;
+        }
+        if (Key == TEXT("hair") || Key == TEXT("msm_hair"))
+        {
+            OutShadingModel = MSM_Hair;
+            return true;
+        }
+        if (Key == TEXT("cloth") || Key == TEXT("msm_cloth"))
+        {
+            OutShadingModel = MSM_Cloth;
+            return true;
+        }
+        if (Key == TEXT("eye") || Key == TEXT("msm_eye"))
+        {
+            OutShadingModel = MSM_Eye;
+            return true;
+        }
+        if (Key == TEXT("singlelayerwater") || Key == TEXT("single_layer_water") || Key == TEXT("msm_singlelayerwater"))
+        {
+            OutShadingModel = MSM_SingleLayerWater;
+            return true;
+        }
+        if (Key == TEXT("thintranslucent") || Key == TEXT("thin_translucent") || Key == TEXT("msm_thintranslucent"))
+        {
+            OutShadingModel = MSM_ThinTranslucent;
+            return true;
+        }
+        return false;
+    }
+
+    static FString GetMaterialDomainName(EMaterialDomain Domain)
+    {
+        switch (Domain)
+        {
+        case EMaterialDomain::MD_Surface:
+            return TEXT("surface");
+        case EMaterialDomain::MD_DeferredDecal:
+            return TEXT("deferred_decal");
+        case EMaterialDomain::MD_LightFunction:
+            return TEXT("light_function");
+        case EMaterialDomain::MD_Volume:
+            return TEXT("volume");
+        case EMaterialDomain::MD_PostProcess:
+            return TEXT("post_process");
+        case EMaterialDomain::MD_UI:
+            return TEXT("ui");
+        default:
+            return TEXT("unknown");
+        }
+    }
+
+    static FString GetBlendModeName(EBlendMode BlendMode)
+    {
+        switch (BlendMode)
+        {
+        case BLEND_Opaque:
+            return TEXT("opaque");
+        case BLEND_Masked:
+            return TEXT("masked");
+        case BLEND_Translucent:
+            return TEXT("translucent");
+        case BLEND_Additive:
+            return TEXT("additive");
+        case BLEND_Modulate:
+            return TEXT("modulate");
+        case BLEND_AlphaComposite:
+            return TEXT("alpha_composite");
+        case BLEND_AlphaHoldout:
+            return TEXT("alpha_holdout");
+        default:
+            return TEXT("unknown");
+        }
+    }
+
+    static FString GetPrimaryShadingModelName(UMaterial* Mat)
+    {
+        if (!Mat)
+        {
+            return TEXT("");
+        }
+
+        const FMaterialShadingModelField Field = Mat->GetShadingModels();
+        if (Field.HasShadingModel(MSM_Unlit))
+        {
+            return TEXT("unlit");
+        }
+        if (Field.HasShadingModel(MSM_DefaultLit))
+        {
+            return TEXT("default_lit");
+        }
+        if (Field.HasShadingModel(MSM_Subsurface))
+        {
+            return TEXT("subsurface");
+        }
+        if (Field.HasShadingModel(MSM_PreintegratedSkin))
+        {
+            return TEXT("preintegrated_skin");
+        }
+        if (Field.HasShadingModel(MSM_ClearCoat))
+        {
+            return TEXT("clear_coat");
+        }
+        if (Field.HasShadingModel(MSM_SubsurfaceProfile))
+        {
+            return TEXT("subsurface_profile");
+        }
+        if (Field.HasShadingModel(MSM_TwoSidedFoliage))
+        {
+            return TEXT("two_sided_foliage");
+        }
+        if (Field.HasShadingModel(MSM_Hair))
+        {
+            return TEXT("hair");
+        }
+        if (Field.HasShadingModel(MSM_Cloth))
+        {
+            return TEXT("cloth");
+        }
+        if (Field.HasShadingModel(MSM_Eye))
+        {
+            return TEXT("eye");
+        }
+        if (Field.HasShadingModel(MSM_SingleLayerWater))
+        {
+            return TEXT("single_layer_water");
+        }
+        if (Field.HasShadingModel(MSM_ThinTranslucent))
+        {
+            return TEXT("thin_translucent");
+        }
+        return TEXT("custom");
+    }
+
+    static FString ResolveColorOutputPin(UMaterial* Mat)
+    {
+        if (!Mat)
+        {
+            return BaseColorPinName;
+        }
+
+        const EMaterialDomain Domain = static_cast<EMaterialDomain>(Mat->MaterialDomain.GetValue());
+        if (Domain == EMaterialDomain::MD_UI ||
+            Domain == EMaterialDomain::MD_PostProcess ||
+            Domain == EMaterialDomain::MD_LightFunction ||
+            Mat->GetShadingModels().HasShadingModel(MSM_Unlit))
+        {
+            return EmissiveColorPinName;
+        }
+        return BaseColorPinName;
+    }
+
+    static FString ResolveAlphaOutputPin(UMaterial* Mat)
+    {
+        if (!Mat)
+        {
+            return TEXT("");
+        }
+
+        const EMaterialDomain Domain = static_cast<EMaterialDomain>(Mat->MaterialDomain.GetValue());
+        const EBlendMode BlendMode = static_cast<EBlendMode>(Mat->BlendMode.GetValue());
+        if (Domain == EMaterialDomain::MD_UI)
+        {
+            return OpacityPinName;
+        }
+        if (BlendMode == BLEND_Masked)
+        {
+            return OpacityMaskPinName;
+        }
+        if (BlendMode != BLEND_Opaque)
+        {
+            return OpacityPinName;
+        }
+        return TEXT("");
+    }
+
+    static FString ResolveMaterialOutputTarget(const FString& Input)
+    {
+        const FString Key = NormalizeMaterialToken(Input);
+        if (Key == TEXT("output"))
+        {
+            return TEXT("Output");
+        }
+        if (Key == TEXT("basecolor") || Key == TEXT("base_color") || Key == TEXT("diffuse"))
+        {
+            return BaseColorPinName;
+        }
+        if (Key == TEXT("emissive") || Key == TEXT("emissivecolor") || Key == TEXT("finalcolor") || Key == TEXT("final_color"))
+        {
+            return EmissiveColorPinName;
+        }
+        if (Key == TEXT("opacity"))
+        {
+            return OpacityPinName;
+        }
+        if (Key == TEXT("opacitymask") || Key == TEXT("opacity_mask"))
+        {
+            return OpacityMaskPinName;
+        }
+        if (Key == TEXT("metallic"))
+        {
+            return TEXT("Metallic");
+        }
+        if (Key == TEXT("specular"))
+        {
+            return TEXT("Specular");
+        }
+        if (Key == TEXT("roughness"))
+        {
+            return TEXT("Roughness");
+        }
+        if (Key == TEXT("anisotropy"))
+        {
+            return TEXT("Anisotropy");
+        }
+        if (Key == TEXT("normal"))
+        {
+            return TEXT("Normal");
+        }
+        if (Key == TEXT("tangent"))
+        {
+            return TEXT("Tangent");
+        }
+        if (Key == TEXT("worldpositionoffset") || Key == TEXT("world_position_offset") || Key == TEXT("wpo"))
+        {
+            return TEXT("WorldPositionOffset");
+        }
+        if (Key == TEXT("subsurface") || Key == TEXT("subsurfacecolor") || Key == TEXT("subsurface_color"))
+        {
+            return TEXT("SubsurfaceColor");
+        }
+        if (Key == TEXT("ambientocclusion") || Key == TEXT("ambient_occlusion") || Key == TEXT("ao"))
+        {
+            return TEXT("AmbientOcclusion");
+        }
+        if (Key == TEXT("refraction"))
+        {
+            return TEXT("Refraction");
+        }
+        if (Key == TEXT("pixeldepthoffset") || Key == TEXT("pixel_depth_offset") || Key == TEXT("pdo"))
+        {
+            return TEXT("PixelDepthOffset");
+        }
+        if (Key == TEXT("customdata0") || Key == TEXT("custom_data_0"))
+        {
+            return TEXT("CustomData0");
+        }
+        if (Key == TEXT("customdata1") || Key == TEXT("custom_data_1"))
+        {
+            return TEXT("CustomData1");
+        }
+        if (Key == TEXT("customizeduv0") || Key == TEXT("customizeduvs0") || Key == TEXT("customized_uv_0") || Key == TEXT("customized_uvs_0"))
+        {
+            return TEXT("CustomizedUVs0");
+        }
+        if (Key == TEXT("customizeduv1") || Key == TEXT("customizeduvs1") || Key == TEXT("customized_uv_1") || Key == TEXT("customized_uvs_1"))
+        {
+            return TEXT("CustomizedUVs1");
+        }
+        if (Key == TEXT("customizeduv2") || Key == TEXT("customizeduvs2") || Key == TEXT("customized_uv_2") || Key == TEXT("customized_uvs_2"))
+        {
+            return TEXT("CustomizedUVs2");
+        }
+        if (Key == TEXT("customizeduv3") || Key == TEXT("customizeduvs3") || Key == TEXT("customized_uv_3") || Key == TEXT("customized_uvs_3"))
+        {
+            return TEXT("CustomizedUVs3");
+        }
+        if (Key == TEXT("customizeduv4") || Key == TEXT("customizeduvs4") || Key == TEXT("customized_uv_4") || Key == TEXT("customized_uvs_4"))
+        {
+            return TEXT("CustomizedUVs4");
+        }
+        if (Key == TEXT("customizeduv5") || Key == TEXT("customizeduvs5") || Key == TEXT("customized_uv_5") || Key == TEXT("customized_uvs_5"))
+        {
+            return TEXT("CustomizedUVs5");
+        }
+        if (Key == TEXT("customizeduv6") || Key == TEXT("customizeduvs6") || Key == TEXT("customized_uv_6") || Key == TEXT("customized_uvs_6"))
+        {
+            return TEXT("CustomizedUVs6");
+        }
+        if (Key == TEXT("customizeduv7") || Key == TEXT("customizeduvs7") || Key == TEXT("customized_uv_7") || Key == TEXT("customized_uvs_7"))
+        {
+            return TEXT("CustomizedUVs7");
+        }
+        if (Key == TEXT("surfacethickness") || Key == TEXT("surface_thickness"))
+        {
+            return TEXT("SurfaceThickness");
+        }
+        if (Key == TEXT("displacement"))
+        {
+            return TEXT("Displacement");
+        }
+        if (Key == TEXT("materialattributes") || Key == TEXT("material_attributes"))
+        {
+            return TEXT("MaterialAttributes");
+        }
+        return Input.TrimStartAndEnd().Replace(TEXT(" "), TEXT(""));
+    }
+
+    static bool IsFloat3MaterialOutput(const FString& Target)
+    {
+        return Target.Equals(BaseColorPinName, ESearchCase::IgnoreCase) ||
+            Target.Equals(EmissiveColorPinName, ESearchCase::IgnoreCase) ||
+            Target.Equals(TEXT("Normal"), ESearchCase::IgnoreCase) ||
+            Target.Equals(TEXT("Tangent"), ESearchCase::IgnoreCase) ||
+            Target.Equals(TEXT("WorldPositionOffset"), ESearchCase::IgnoreCase) ||
+            Target.Equals(TEXT("SubsurfaceColor"), ESearchCase::IgnoreCase);
+    }
+
+    static bool IsFloat2MaterialOutput(const FString& Target)
+    {
+        return Target.StartsWith(TEXT("CustomizedUVs"), ESearchCase::IgnoreCase);
+    }
+
+    static ECustomMaterialOutputType DefaultCustomOutputTypeForTarget(const FString& Target)
+    {
+        if (Target.Equals(TEXT("MaterialAttributes"), ESearchCase::IgnoreCase))
+        {
+            return CMOT_MaterialAttributes;
+        }
+        if (IsFloat3MaterialOutput(Target))
+        {
+            return CMOT_Float3;
+        }
+        if (IsFloat2MaterialOutput(Target))
+        {
+            return CMOT_Float2;
+        }
+        return CMOT_Float1;
+    }
+
+    static bool ParseCustomOutputType(const FString& Input, ECustomMaterialOutputType& OutType)
+    {
+        const FString Key = NormalizeMaterialToken(Input);
+        if (Key == TEXT("float") || Key == TEXT("float1") || Key == TEXT("scalar") || Key == TEXT("cmot_float1"))
+        {
+            OutType = CMOT_Float1;
+            return true;
+        }
+        if (Key == TEXT("float2") || Key == TEXT("vector2") || Key == TEXT("cmot_float2"))
+        {
+            OutType = CMOT_Float2;
+            return true;
+        }
+        if (Key == TEXT("float3") || Key == TEXT("vector3") || Key == TEXT("rgb") || Key == TEXT("cmot_float3"))
+        {
+            OutType = CMOT_Float3;
+            return true;
+        }
+        if (Key == TEXT("float4") || Key == TEXT("vector4") || Key == TEXT("rgba") || Key == TEXT("cmot_float4"))
+        {
+            OutType = CMOT_Float4;
+            return true;
+        }
+        if (Key == TEXT("materialattributes") || Key == TEXT("material_attributes") || Key == TEXT("cmot_materialattributes"))
+        {
+            OutType = CMOT_MaterialAttributes;
+            return true;
+        }
+        return false;
+    }
+
+    static FString GetCustomOutputTypeName(ECustomMaterialOutputType Type)
+    {
+        switch (Type)
+        {
+        case CMOT_Float2:
+            return TEXT("float2");
+        case CMOT_Float3:
+            return TEXT("float3");
+        case CMOT_Float4:
+            return TEXT("float4");
+        case CMOT_MaterialAttributes:
+            return TEXT("material_attributes");
+        case CMOT_Float1:
+        default:
+            return TEXT("float1");
+        }
+    }
+
+    static bool IsValidHlslIdentifier(const FString& Name)
+    {
+        if (Name.IsEmpty())
+        {
+            return false;
+        }
+
+        const TCHAR First = Name[0];
+        if (!(FChar::IsAlpha(First) || First == TEXT('_')))
+        {
+            return false;
+        }
+
+        for (int32 i = 1; i < Name.Len(); ++i)
+        {
+            const TCHAR Ch = Name[i];
+            if (!(FChar::IsAlnum(Ch) || Ch == TEXT('_')))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool HasMaterialTypeOptions(const TSharedPtr<FJsonObject>& Params)
+    {
+        return Params.IsValid() &&
+            (Params->HasField(TEXT("domain")) ||
+             Params->HasField(TEXT("blend_mode")) ||
+             Params->HasField(TEXT("shading_model")) ||
+             Params->HasField(TEXT("two_sided")));
+    }
+
+    static bool ApplyMaterialTypeOptions(UMaterial* Mat, const TSharedPtr<FJsonObject>& Params, FString& OutError)
+    {
+        OutError = TEXT("");
+        if (!Mat || !Params.IsValid())
+        {
+            OutError = TEXT("No target material");
+            return false;
+        }
+
+        bool bSetDomain = false;
+        bool bSetBlendMode = false;
+        bool bSetShadingModel = false;
+        bool bSetTwoSided = false;
+        EMaterialDomain NewDomain = static_cast<EMaterialDomain>(Mat->MaterialDomain.GetValue());
+        EBlendMode NewBlendMode = static_cast<EBlendMode>(Mat->BlendMode.GetValue());
+        EMaterialShadingModel NewShadingModel = MSM_DefaultLit;
+        bool bNewTwoSided = Mat->TwoSided != 0;
+
+        FString DomainStr;
+        if (Params->TryGetStringField(TEXT("domain"), DomainStr))
+        {
+            if (!ParseMaterialDomain(DomainStr, NewDomain))
+            {
+                OutError = FString::Printf(TEXT("Unsupported material domain: %s"), *DomainStr);
+                return false;
+            }
+            bSetDomain = true;
+        }
+
+        FString BlendModeStr;
+        if (Params->TryGetStringField(TEXT("blend_mode"), BlendModeStr))
+        {
+            if (!ParseBlendMode(BlendModeStr, NewBlendMode))
+            {
+                OutError = FString::Printf(TEXT("Unsupported blend mode: %s"), *BlendModeStr);
+                return false;
+            }
+            bSetBlendMode = true;
+        }
+
+        FString ShadingModelStr;
+        if (Params->TryGetStringField(TEXT("shading_model"), ShadingModelStr))
+        {
+            if (!ParseShadingModel(ShadingModelStr, NewShadingModel))
+            {
+                OutError = FString::Printf(TEXT("Unsupported shading model: %s"), *ShadingModelStr);
+                return false;
+            }
+            bSetShadingModel = true;
+        }
+
+        if (Params->HasField(TEXT("two_sided")))
+        {
+            if (!Params->TryGetBoolField(TEXT("two_sided"), bNewTwoSided))
+            {
+                OutError = TEXT("'two_sided' must be a boolean");
+                return false;
+            }
+            bSetTwoSided = true;
+        }
+
+        if (bSetDomain || bSetBlendMode || bSetShadingModel || bSetTwoSided)
+        {
+            Mat->Modify();
+            Mat->PreEditChange(nullptr);
+            if (bSetDomain)
+            {
+                Mat->MaterialDomain = NewDomain;
+            }
+            if (bSetBlendMode)
+            {
+                Mat->BlendMode = NewBlendMode;
+            }
+            if (bSetShadingModel)
+            {
+                Mat->SetShadingModel(NewShadingModel);
+            }
+            if (bSetTwoSided)
+            {
+                Mat->TwoSided = bNewTwoSided;
+            }
+            Mat->PostEditChange();
+            Mat->MarkPackageDirty();
+        }
+
+        return true;
+    }
+
+    static bool IsMaterialInputConnected(UMaterial* Mat, const FString& InputName)
+    {
+        if (InputName.IsEmpty())
+        {
+            return false;
+        }
+        FExpressionInput* Input = FindMaterialInputByName(Mat, InputName);
+        return Input && Input->Expression != nullptr;
+    }
+
+    static FString FindConnectedTargetForCustomOutput(UMaterial* Mat, UMaterialExpressionCustom* CustomNode, int32 OutputIndex)
+    {
+        if (!Mat || !CustomNode)
+        {
+            return TEXT("");
+        }
+
+        auto FindInObject = [&](UObject* Owner) -> FString
+        {
+            if (!Owner)
+            {
+                return TEXT("");
+            }
+
+            for (TFieldIterator<FProperty> It(Owner->GetClass()); It; ++It)
+            {
+                FProperty* Prop = *It;
+                FStructProperty* StructProp = CastField<FStructProperty>(Prop);
+                if (!StructProp || !StructProp->Struct)
+                {
+                    continue;
+                }
+
+                const FString StructName = StructProp->Struct->GetName();
+                if (!StructName.Equals(TEXT("ExpressionInput")) && !StructName.Contains(TEXT("MaterialInput")))
+                {
+                    continue;
+                }
+
+                FExpressionInput* Input = StructProp->ContainerPtrToValuePtr<FExpressionInput>(Owner);
+                if (Input && Input->Expression == CustomNode && Input->OutputIndex == OutputIndex)
+                {
+                    return Prop->GetName();
+                }
+            }
+            return TEXT("");
+        };
+
+#if WITH_EDITOR
+        if (Mat->GetEditorOnlyData())
+        {
+            const FString EditorOnlyResult = FindInObject((UObject*)Mat->GetEditorOnlyData());
+            if (!EditorOnlyResult.IsEmpty())
+            {
+                return EditorOnlyResult;
+            }
+        }
+#endif
+        return FindInObject(Mat);
+    }
+
+    static void BuildHlslOutputSnapshot(UMaterial* Mat, UMaterialExpressionCustom* CustomNode, TArray<TSharedPtr<FJsonValue>>& OutOutputs)
+    {
+        OutOutputs.Empty();
+        if (!CustomNode)
+        {
+            return;
+        }
+
+        for (int32 i = 0; i < CustomNode->AdditionalOutputs.Num(); ++i)
+        {
+            const FCustomOutput& Output = CustomNode->AdditionalOutputs[i];
+            if (Output.OutputName.IsNone())
+            {
+                continue;
+            }
+
+            const int32 OutputIndex = i + 1;
+            const FString Name = Output.OutputName.ToString();
+            const FString ConnectedTarget = FindConnectedTargetForCustomOutput(Mat, CustomNode, OutputIndex);
+
+            TSharedPtr<FJsonObject> OutputObj = MakeShareable(new FJsonObject);
+            OutputObj->SetStringField(TEXT("name"), Name);
+            OutputObj->SetStringField(TEXT("target"), ConnectedTarget.IsEmpty() ? ResolveMaterialOutputTarget(Name) : ConnectedTarget);
+            OutputObj->SetStringField(TEXT("type"), GetCustomOutputTypeName(static_cast<ECustomMaterialOutputType>(Output.OutputType.GetValue())));
+            OutputObj->SetBoolField(TEXT("connected"), !ConnectedTarget.IsEmpty());
+            OutOutputs.Add(MakeShareable(new FJsonValueObject(OutputObj)));
+        }
+    }
+
+    static TSharedPtr<FJsonObject> BuildOutputContract(UMaterial* Mat, UMaterialExpressionCustom* CustomNode = nullptr)
+    {
+        TSharedPtr<FJsonObject> OutputContract = MakeShareable(new FJsonObject);
+        OutputContract->SetStringField(TEXT("return"), TEXT("float4"));
+        if (Mat)
+        {
+            OutputContract->SetStringField(TEXT("domain"), GetMaterialDomainName(static_cast<EMaterialDomain>(Mat->MaterialDomain.GetValue())));
+            OutputContract->SetStringField(TEXT("blend_mode"), GetBlendModeName(static_cast<EBlendMode>(Mat->BlendMode.GetValue())));
+            OutputContract->SetStringField(TEXT("shading_model"), GetPrimaryShadingModelName(Mat));
+        }
+        OutputContract->SetStringField(TEXT("rgb_to"), ResolveColorOutputPin(Mat));
+
+        const FString AlphaPin = ResolveAlphaOutputPin(Mat);
+        if (!AlphaPin.IsEmpty())
+        {
+            OutputContract->SetStringField(TEXT("a_to"), AlphaPin);
+        }
+
+        TArray<TSharedPtr<FJsonValue>> AdditionalOutputs;
+        BuildHlslOutputSnapshot(Mat, CustomNode, AdditionalOutputs);
+        if (AdditionalOutputs.Num() > 0)
+        {
+            OutputContract->SetArrayField(TEXT("outputs"), AdditionalOutputs);
+        }
+        return OutputContract;
+    }
+
+    template <typename TExpression>
+    static TExpression* FindExpressionByDesc(UMaterial* Mat, const TCHAR* Desc)
+    {
+        if (!Mat)
+        {
+            return nullptr;
+        }
+
+        for (UMaterialExpression* Expr : Mat->GetExpressions())
+        {
+            if (TExpression* Typed = Cast<TExpression>(Expr))
+            {
+                if (Typed->Desc.Equals(Desc, ESearchCase::IgnoreCase))
+                {
+                    return Typed;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    static bool RefreshHlslOutputWiring(UUmgMcpMaterialSubsystem* Subsystem, UMaterial* Mat, FString& OutError)
+    {
+        if (!Subsystem || !Mat)
+        {
+            OutError = TEXT("No material target");
+            return false;
+        }
+
+        UMaterialExpressionComponentMask* RgbMask = FindExpressionByDesc<UMaterialExpressionComponentMask>(Mat, HlslRgbDesc);
+        UMaterialExpressionComponentMask* AlphaMask = FindExpressionByDesc<UMaterialExpressionComponentMask>(Mat, HlslAlphaDesc);
+        if (!RgbMask)
+        {
+            OutError = TEXT("HLSL RGB mask not found; call hlsl_set_target first to create topology");
+            return false;
+        }
+
+        const FString ColorPin = ResolveColorOutputPin(Mat);
+        bool bLinkOk = Subsystem->ConnectPins(RgbMask->GetName(), TEXT(""), MasterHandleName, ColorPin);
+
+        const FString AlphaPin = ResolveAlphaOutputPin(Mat);
+        if (!AlphaPin.IsEmpty() && AlphaMask)
+        {
+            bLinkOk = Subsystem->ConnectPins(AlphaMask->GetName(), TEXT(""), MasterHandleName, AlphaPin) && bLinkOk;
+        }
+
+        if (!bLinkOk)
+        {
+            OutError = FString::Printf(TEXT("Failed to refresh HLSL output wiring (%s%s%s)"),
+                *ColorPin,
+                AlphaPin.IsEmpty() ? TEXT("") : TEXT(", "),
+                *AlphaPin);
+            return false;
+        }
+
+        OutError = TEXT("");
+        return true;
+    }
+
     static FString DetectParamKind(const UMaterialExpression* Expr)
     {
         if (Cast<UMaterialExpressionScalarParameter>(Expr))
@@ -137,12 +938,6 @@ namespace
             return false;
         }
 
-        if (Mat->MaterialDomain != MD_UI)
-        {
-            OutReason = TEXT("Target material is not a UI material (MaterialDomain != MD_UI)");
-            return false;
-        }
-
         UMaterialExpressionCustom* CustomNode = FindSingleCustomNode(Mat);
         if (!CustomNode)
         {
@@ -150,14 +945,23 @@ namespace
             return false;
         }
 
-        FExpressionInput* FinalColorInput = FindMaterialInputByName(Mat, TEXT("EmissiveColor"));
-        FExpressionInput* OpacityInput = FindMaterialInputByName(Mat, OpacityPinName);
-        const bool bHasFinalColor = FinalColorInput && FinalColorInput->Expression != nullptr;
-        const bool bHasOpacity = OpacityInput && OpacityInput->Expression != nullptr;
-
-        if (!bHasFinalColor && !bHasOpacity)
+        if (CustomNode->OutputType != CMOT_Float4)
         {
-            OutReason = TEXT("UI output is not connected");
+            OutReason = TEXT("Custom HLSL node primary output must be float4");
+            return false;
+        }
+
+        const FString ColorPin = ResolveColorOutputPin(Mat);
+        const FString AlphaPin = ResolveAlphaOutputPin(Mat);
+        const bool bHasColor = IsMaterialInputConnected(Mat, ColorPin);
+        const bool bHasAlpha = IsMaterialInputConnected(Mat, AlphaPin);
+
+        if (!bHasColor && !bHasAlpha)
+        {
+            OutReason = FString::Printf(TEXT("HLSL output is not connected to active material outputs (expected %s%s%s)"),
+                *ColorPin,
+                AlphaPin.IsEmpty() ? TEXT("") : TEXT(" / "),
+                *AlphaPin);
             return false;
         }
 
@@ -196,18 +1000,19 @@ namespace
         }
 
         CustomNode->Desc = TEXT("HLSL_Core");
+        CustomNode->OutputType = CMOT_Float4;
         if (CustomNode->Code.IsEmpty())
         {
             CustomNode->Code = DefaultBootstrapHlsl;
         }
 
-        RgbMask->Desc = TEXT("HLSL_RGB");
+        RgbMask->Desc = HlslRgbDesc;
         RgbMask->R = true;
         RgbMask->G = true;
         RgbMask->B = true;
         RgbMask->A = false;
 
-        AlphaMask->Desc = TEXT("HLSL_A");
+        AlphaMask->Desc = HlslAlphaDesc;
         AlphaMask->R = false;
         AlphaMask->G = false;
         AlphaMask->B = false;
@@ -217,11 +1022,17 @@ namespace
         const FString RgbHandle = RgbMask->GetName();
         const FString AlphaHandle = AlphaMask->GetName();
 
-        const bool bLinkOk =
+        const FString ColorPin = ResolveColorOutputPin(Mat);
+        const FString AlphaPin = ResolveAlphaOutputPin(Mat);
+        bool bLinkOk =
             Subsystem->ConnectPins(CustomHandle, TEXT(""), RgbHandle, TEXT("Input")) &&
             Subsystem->ConnectPins(CustomHandle, TEXT(""), AlphaHandle, TEXT("Input")) &&
-            Subsystem->ConnectPins(RgbHandle, TEXT(""), MasterHandleName, FinalColorPinName) &&
-            Subsystem->ConnectPins(AlphaHandle, TEXT(""), MasterHandleName, OpacityPinName);
+            Subsystem->ConnectPins(RgbHandle, TEXT(""), MasterHandleName, ColorPin);
+
+        if (!AlphaPin.IsEmpty())
+        {
+            bLinkOk = Subsystem->ConnectPins(AlphaHandle, TEXT(""), MasterHandleName, AlphaPin) && bLinkOk;
+        }
 
         if (!bLinkOk)
         {
@@ -264,6 +1075,61 @@ namespace
         bool bDelete = false;
     };
 
+    struct FHlslOutputDraft
+    {
+        FString Name;
+        FString Target;
+        ECustomMaterialOutputType Type = CMOT_Float1;
+        bool bDelete = false;
+    };
+
+    static void ClearCustomAdditionalOutputConnections(UMaterial* Mat, UMaterialExpressionCustom* CustomNode)
+    {
+        if (!Mat || !CustomNode)
+        {
+            return;
+        }
+
+        auto ClearInObject = [&](UObject* Owner)
+        {
+            if (!Owner)
+            {
+                return;
+            }
+
+            for (TFieldIterator<FProperty> It(Owner->GetClass()); It; ++It)
+            {
+                FProperty* Prop = *It;
+                FStructProperty* StructProp = CastField<FStructProperty>(Prop);
+                if (!StructProp || !StructProp->Struct)
+                {
+                    continue;
+                }
+
+                const FString StructName = StructProp->Struct->GetName();
+                if (!StructName.Equals(TEXT("ExpressionInput")) && !StructName.Contains(TEXT("MaterialInput")))
+                {
+                    continue;
+                }
+
+                FExpressionInput* Input = StructProp->ContainerPtrToValuePtr<FExpressionInput>(Owner);
+                if (Input && Input->Expression == CustomNode && Input->OutputIndex > 0)
+                {
+                    Input->Expression = nullptr;
+                    Input->OutputIndex = 0;
+                }
+            }
+        };
+
+#if WITH_EDITOR
+        if (Mat->GetEditorOnlyData())
+        {
+            ClearInObject((UObject*)Mat->GetEditorOnlyData());
+        }
+#endif
+        ClearInObject(Mat);
+    }
+
     static void ParseParameterDrafts(const TArray<TSharedPtr<FJsonValue>>& JsonParams, TArray<FHlslParamDraft>& OutDrafts)
     {
         OutDrafts.Empty();
@@ -297,6 +1163,236 @@ namespace
                 OutDrafts.Add(Draft);
             }
         }
+    }
+
+    static void ParseOutputDrafts(const TArray<TSharedPtr<FJsonValue>>& JsonOutputs, TArray<FHlslOutputDraft>& OutDrafts, FString& OutError)
+    {
+        OutDrafts.Empty();
+        OutError = TEXT("");
+
+        for (const TSharedPtr<FJsonValue>& JsonVal : JsonOutputs)
+        {
+            FHlslOutputDraft Draft;
+            bool bExplicitType = false;
+
+            if (JsonVal->Type == EJson::String)
+            {
+                Draft.Target = ResolveMaterialOutputTarget(JsonVal->AsString());
+                Draft.Name = Draft.Target.Equals(TEXT("Output"), ESearchCase::IgnoreCase) ? ResolveMaterialOutputTarget(JsonVal->AsString()) : Draft.Target;
+            }
+            else if (JsonVal->Type == EJson::Object)
+            {
+                const TSharedPtr<FJsonObject> Obj = JsonVal->AsObject();
+                if (!Obj.IsValid())
+                {
+                    continue;
+                }
+
+                FString Target;
+                Obj->TryGetStringField(TEXT("target"), Target);
+                FString Name;
+                Obj->TryGetStringField(TEXT("name"), Name);
+                if (Target.IsEmpty())
+                {
+                    Target = Name;
+                }
+
+                Draft.Target = ResolveMaterialOutputTarget(Target);
+                Draft.Name = Name.IsEmpty() ? Draft.Target : Name.TrimStartAndEnd().Replace(TEXT(" "), TEXT(""));
+
+                FString TypeStr;
+                if (Obj->TryGetStringField(TEXT("type"), TypeStr))
+                {
+                    if (!ParseCustomOutputType(TypeStr, Draft.Type))
+                    {
+                        OutError = FString::Printf(TEXT("Unsupported HLSL output type: %s"), *TypeStr);
+                        return;
+                    }
+                    bExplicitType = true;
+                }
+
+                bool bDeleteFlag = false;
+                Obj->TryGetBoolField(TEXT("delete"), bDeleteFlag);
+                FString Action;
+                Obj->TryGetStringField(TEXT("action"), Action);
+                Draft.bDelete = bDeleteFlag || Action.Equals(TEXT("delete"), ESearchCase::IgnoreCase);
+            }
+            else
+            {
+                continue;
+            }
+
+            if (Draft.Target.IsEmpty())
+            {
+                OutError = TEXT("HLSL output target cannot be empty");
+                return;
+            }
+
+            if (Draft.Name.IsEmpty())
+            {
+                Draft.Name = Draft.Target;
+            }
+
+            if (!IsValidHlslIdentifier(Draft.Name))
+            {
+                OutError = FString::Printf(TEXT("Invalid HLSL output name '%s'. Use a valid HLSL identifier."), *Draft.Name);
+                return;
+            }
+
+            if (!bExplicitType)
+            {
+                Draft.Type = DefaultCustomOutputTypeForTarget(Draft.Target);
+            }
+
+            OutDrafts.Add(Draft);
+        }
+    }
+
+    static bool RebuildHlslOutputs(UUmgMcpMaterialSubsystem* Subsystem, UMaterial* Mat, UMaterialExpressionCustom* CustomNode, const TArray<FHlslOutputDraft>& Outputs, FString& OutError)
+    {
+        if (!Subsystem || !Mat || !CustomNode)
+        {
+            OutError = TEXT("No HLSL material target");
+            return false;
+        }
+
+        ClearCustomAdditionalOutputConnections(Mat, CustomNode);
+
+        CustomNode->Modify();
+        CustomNode->OutputType = CMOT_Float4;
+        CustomNode->AdditionalOutputs.Empty();
+        for (const FHlslOutputDraft& Output : Outputs)
+        {
+            FCustomOutput NewOutput;
+            NewOutput.OutputName = *Output.Name;
+            NewOutput.OutputType = Output.Type;
+            CustomNode->AdditionalOutputs.Add(NewOutput);
+        }
+
+#if WITH_EDITOR
+        CustomNode->RebuildOutputs();
+#endif
+        CustomNode->PostEditChange();
+        Mat->PostEditChange();
+        Mat->MarkPackageDirty();
+
+        for (const FHlslOutputDraft& Output : Outputs)
+        {
+            if (!Subsystem->ConnectPins(CustomNode->GetName(), Output.Name, MasterHandleName, Output.Target))
+            {
+                OutError = FString::Printf(TEXT("Failed to connect HLSL output '%s' to material target '%s'"), *Output.Name, *Output.Target);
+                return false;
+            }
+        }
+
+        OutError = TEXT("");
+        return true;
+    }
+
+    static bool ApplyHlslOutputs(UUmgMcpMaterialSubsystem* Subsystem, UMaterial* Mat, UMaterialExpressionCustom* CustomNode, const TArray<FHlslOutputDraft>& Incoming, FString& OutError)
+    {
+        if (!Subsystem || !Mat || !CustomNode)
+        {
+            OutError = TEXT("No HLSL material target");
+            return false;
+        }
+
+        TArray<FHlslOutputDraft> WorkingOutputs;
+        for (int32 i = 0; i < CustomNode->AdditionalOutputs.Num(); ++i)
+        {
+            const FCustomOutput& Existing = CustomNode->AdditionalOutputs[i];
+            if (Existing.OutputName.IsNone())
+            {
+                continue;
+            }
+
+            FHlslOutputDraft Draft;
+            Draft.Name = Existing.OutputName.ToString();
+            Draft.Type = static_cast<ECustomMaterialOutputType>(Existing.OutputType.GetValue());
+            const FString ConnectedTarget = FindConnectedTargetForCustomOutput(Mat, CustomNode, i + 1);
+            Draft.Target = ConnectedTarget.IsEmpty() ? ResolveMaterialOutputTarget(Draft.Name) : ConnectedTarget;
+            WorkingOutputs.Add(Draft);
+        }
+
+        for (const FHlslOutputDraft& Item : Incoming)
+        {
+            if (Item.bDelete)
+            {
+                OutError = TEXT("hlsl_set is union-only and cannot delete outputs. Use hlsl_delete_output with confirm_delete=true.");
+                return false;
+            }
+
+            int32 ExistingIndex = INDEX_NONE;
+            for (int32 i = 0; i < WorkingOutputs.Num(); ++i)
+            {
+                if (WorkingOutputs[i].Name.Equals(Item.Name, ESearchCase::IgnoreCase) ||
+                    WorkingOutputs[i].Target.Equals(Item.Target, ESearchCase::IgnoreCase))
+                {
+                    ExistingIndex = i;
+                    break;
+                }
+            }
+
+            if (ExistingIndex != INDEX_NONE)
+            {
+                WorkingOutputs[ExistingIndex].Name = Item.Name;
+                WorkingOutputs[ExistingIndex].Target = Item.Target;
+                WorkingOutputs[ExistingIndex].Type = Item.Type;
+            }
+            else
+            {
+                WorkingOutputs.Add(Item);
+            }
+        }
+
+        return RebuildHlslOutputs(Subsystem, Mat, CustomNode, WorkingOutputs, OutError);
+    }
+
+    static bool DeleteHlslOutputs(UUmgMcpMaterialSubsystem* Subsystem, UMaterial* Mat, UMaterialExpressionCustom* CustomNode, const TArray<FString>& NamesOrTargets, TArray<FString>& OutDeleted, FString& OutError)
+    {
+        OutDeleted.Empty();
+        if (!Subsystem || !Mat || !CustomNode)
+        {
+            OutError = TEXT("No HLSL material target");
+            return false;
+        }
+
+        TArray<FHlslOutputDraft> KeptOutputs;
+
+        for (int32 i = 0; i < CustomNode->AdditionalOutputs.Num(); ++i)
+        {
+            const FCustomOutput& Existing = CustomNode->AdditionalOutputs[i];
+            const FString Name = Existing.OutputName.ToString();
+            const FString ConnectedTarget = FindConnectedTargetForCustomOutput(Mat, CustomNode, i + 1);
+            const FString Target = ConnectedTarget.IsEmpty() ? ResolveMaterialOutputTarget(Name) : ConnectedTarget;
+
+            const bool bDeleteThis = NamesOrTargets.ContainsByPredicate([&Name, &Target](const FString& Candidate)
+            {
+                const FString CanonicalCandidate = ResolveMaterialOutputTarget(Candidate);
+                return Candidate.Equals(Name, ESearchCase::IgnoreCase) || CanonicalCandidate.Equals(Target, ESearchCase::IgnoreCase);
+            });
+
+            if (bDeleteThis)
+            {
+                OutDeleted.Add(Name);
+            }
+            else
+            {
+                FHlslOutputDraft Kept;
+                Kept.Name = Name;
+                Kept.Target = Target;
+                Kept.Type = static_cast<ECustomMaterialOutputType>(Existing.OutputType.GetValue());
+                KeptOutputs.Add(Kept);
+            }
+        }
+
+        if (OutDeleted.Num() == 0)
+        {
+            OutError = TEXT("No matching HLSL output found.");
+            return false;
+        }
+
+        return RebuildHlslOutputs(Subsystem, Mat, CustomNode, KeptOutputs, OutError);
     }
 }
 
@@ -337,7 +1433,7 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
         {
             // Default to always trying to create/load (Context Anchor)
             FString Status = Subsystem->SetTargetMaterial(Path, true);
-            
+
             if (IsErrorStatus(Status))
             {
                  ResultJson->SetStringField(TEXT("error"), Status);
@@ -357,6 +1453,58 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
             ResultJson->SetStringField(TEXT("error"), TEXT("Missing 'path' parameter"));
             ResultJson->SetBoolField(TEXT("success"), false);
         }
+    }
+    else if (CommandType == TEXT("material_modify_type"))
+    {
+        FString Path;
+        if (Params->TryGetStringField(TEXT("path"), Path) && !Path.IsEmpty())
+        {
+            const FString Status = Subsystem->SetTargetMaterial(Path, true);
+            if (IsErrorStatus(Status))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), Status);
+                return ResultJson;
+            }
+        }
+
+        UMaterial* Mat = Subsystem->GetTargetMaterial();
+        if (!Mat)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("No target material. Call material_set_target or hlsl_set_target first."));
+            return ResultJson;
+        }
+
+        FString TypeError;
+        if (!ApplyMaterialTypeOptions(Mat, Params, TypeError))
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TypeError);
+            return ResultJson;
+        }
+
+        bool bRefreshHlslWiring = true;
+        Params->TryGetBoolField(TEXT("refresh_hlsl_wiring"), bRefreshHlslWiring);
+        FString WiringStatus = TEXT("skipped");
+        FString WiringError;
+        if (bRefreshHlslWiring && FindSingleCustomNode(Mat))
+        {
+            WiringStatus = RefreshHlslOutputWiring(Subsystem, Mat, WiringError) ? TEXT("refreshed") : TEXT("warning");
+        }
+
+        ResultJson->SetBoolField(TEXT("success"), true);
+        ResultJson->SetStringField(TEXT("target"), Mat->GetPathName());
+        ResultJson->SetStringField(TEXT("domain"), GetMaterialDomainName(static_cast<EMaterialDomain>(Mat->MaterialDomain.GetValue())));
+        ResultJson->SetStringField(TEXT("blend_mode"), GetBlendModeName(static_cast<EBlendMode>(Mat->BlendMode.GetValue())));
+        ResultJson->SetStringField(TEXT("shading_model"), GetPrimaryShadingModelName(Mat));
+        ResultJson->SetBoolField(TEXT("two_sided"), Mat->TwoSided != 0);
+        ResultJson->SetStringField(TEXT("hlsl_wiring"), WiringStatus);
+        if (!WiringError.IsEmpty())
+        {
+            ResultJson->SetStringField(TEXT("hlsl_wiring_warning"), WiringError);
+        }
+        ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, FindSingleCustomNode(Mat)));
     }
     else if (CommandType == TEXT("hlsl_set_target"))
     {
@@ -382,9 +1530,36 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
         UMaterialExpressionCustom* CustomNode = nullptr;
         FString ValidationReason;
 
+        auto ApplyTypeOptionsIfRequested = [&]() -> bool
+        {
+            if (!HasMaterialTypeOptions(Params))
+            {
+                return true;
+            }
+
+            FString TypeError;
+            if (!ApplyMaterialTypeOptions(Mat, Params, TypeError))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), TypeError);
+                return false;
+            }
+
+            if (FindSingleCustomNode(Mat))
+            {
+                FString RefreshError;
+                RefreshHlslOutputWiring(Subsystem, Mat, RefreshError);
+            }
+            return true;
+        };
+
         if (!IsErrorStatus(LoadStatus))
         {
             Mat = Subsystem->GetTargetMaterial();
+            if (!ApplyTypeOptionsIfRequested())
+            {
+                return ResultJson;
+            }
             if (IsValidHlslTarget(Mat, CustomNode, ValidationReason))
             {
                 ResultJson->SetBoolField(TEXT("success"), true);
@@ -392,6 +1567,7 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
                 ResultJson->SetStringField(TEXT("action"), TEXT("loaded"));
                 ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(CustomNode));
                 ResultJson->SetStringField(TEXT("message"), TEXT("HLSL target ready"));
+                ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, CustomNode));
             }
             else if (!bConfirmOverwrite)
             {
@@ -403,6 +1579,10 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
             else
             {
                 FString BootstrapError;
+                if (!ApplyTypeOptionsIfRequested())
+                {
+                    return ResultJson;
+                }
                 if (ResetToSingleHlslTopology(Subsystem, Mat, CustomNode, BootstrapError))
                 {
                     ResultJson->SetBoolField(TEXT("success"), true);
@@ -410,6 +1590,7 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
                     ResultJson->SetStringField(TEXT("action"), TEXT("overwritten"));
                     ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(CustomNode));
                     ResultJson->SetStringField(TEXT("message"), TEXT("HLSL topology overwritten successfully"));
+                    ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, CustomNode));
                 }
                 else
                 {
@@ -429,6 +1610,10 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
             else
             {
                 Mat = Subsystem->GetTargetMaterial();
+                if (!ApplyTypeOptionsIfRequested())
+                {
+                    return ResultJson;
+                }
                 FString BootstrapError;
                 if (ResetToSingleHlslTopology(Subsystem, Mat, CustomNode, BootstrapError))
                 {
@@ -437,6 +1622,7 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
                     ResultJson->SetStringField(TEXT("action"), TEXT("created"));
                     ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(CustomNode));
                     ResultJson->SetStringField(TEXT("message"), TEXT("Created and initialized HLSL target"));
+                    ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, CustomNode));
                 }
                 else
                 {
@@ -466,17 +1652,12 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
         TArray<TSharedPtr<FJsonValue>> ParamsArray;
         BuildParameterSnapshot(CustomNode, ParamsArray);
 
-        TSharedPtr<FJsonObject> OutputContract = MakeShareable(new FJsonObject);
-        OutputContract->SetStringField(TEXT("return"), TEXT("float4"));
-        OutputContract->SetStringField(TEXT("rgb_to"), FinalColorPinName);
-        OutputContract->SetStringField(TEXT("a_to"), OpacityPinName);
-
         ResultJson->SetBoolField(TEXT("success"), true);
         ResultJson->SetStringField(TEXT("target"), Mat ? Mat->GetPathName() : TEXT(""));
         ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(CustomNode));
         ResultJson->SetStringField(TEXT("hlsl"), CustomNode ? CustomNode->Code : TEXT(""));
         ResultJson->SetArrayField(TEXT("parameters"), ParamsArray);
-        ResultJson->SetObjectField(TEXT("output_contract"), OutputContract);
+        ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, CustomNode));
     }
     else if (CommandType == TEXT("hlsl_set"))
     {
@@ -494,12 +1675,27 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
         const bool bHasHlsl = Params->TryGetStringField(TEXT("hlsl"), NewHlsl);
         const TArray<TSharedPtr<FJsonValue>>* NewParametersJson = nullptr;
         const bool bHasParameters = Params->TryGetArrayField(TEXT("parameters"), NewParametersJson);
+        const TArray<TSharedPtr<FJsonValue>>* NewOutputsJson = nullptr;
+        const bool bHasOutputs = Params->TryGetArrayField(TEXT("outputs"), NewOutputsJson);
 
-        if (!bHasHlsl && !bHasParameters)
+        if (!bHasHlsl && !bHasParameters && !bHasOutputs)
         {
             ResultJson->SetBoolField(TEXT("success"), false);
-            ResultJson->SetStringField(TEXT("error"), TEXT("Provide at least one of 'hlsl' or 'parameters'"));
+            ResultJson->SetStringField(TEXT("error"), TEXT("Provide at least one of 'hlsl', 'parameters', or 'outputs'"));
             return ResultJson;
+        }
+
+        TArray<FHlslOutputDraft> IncomingOutputs;
+        if (bHasOutputs)
+        {
+            FString OutputParseError;
+            ParseOutputDrafts(*NewOutputsJson, IncomingOutputs, OutputParseError);
+            if (!OutputParseError.IsEmpty())
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), OutputParseError);
+                return ResultJson;
+            }
         }
 
         // Collect existing parameters from current custom input list
@@ -516,6 +1712,16 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
         {
             TArray<FHlslParamDraft> Incoming;
             ParseParameterDrafts(*NewParametersJson, Incoming);
+
+            for (const FHlslParamDraft& Item : Incoming)
+            {
+                if (Item.bDelete)
+                {
+                    ResultJson->SetBoolField(TEXT("success"), false);
+                    ResultJson->SetStringField(TEXT("error"), TEXT("hlsl_set is union-only and cannot delete parameters. Use hlsl_delete_parameter with confirm_delete=true."));
+                    return ResultJson;
+                }
+            }
 
             for (const FHlslParamDraft& Item : Incoming)
             {
@@ -581,16 +1787,518 @@ TSharedPtr<FJsonObject> FUmgMcpMaterialCommands::HandleCommand(const FString& Co
             Subsystem->ConnectPins(ParamHandle, TEXT(""), CustomNode->GetName(), Param.Name);
         }
 
+        if (bHasOutputs)
+        {
+            FString OutputApplyError;
+            if (!ApplyHlslOutputs(Subsystem, Mat, CustomNode, IncomingOutputs, OutputApplyError))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), OutputApplyError);
+                return ResultJson;
+            }
+        }
+
         // Re-validate and expose resulting parameter list
         UMaterialExpressionCustom* NewCustomNode = FindSingleCustomNode(Subsystem->GetTargetMaterial());
         TArray<TSharedPtr<FJsonValue>> ParametersOut;
         BuildParameterSnapshot(NewCustomNode, ParametersOut);
+        TArray<TSharedPtr<FJsonValue>> OutputsOut;
+        BuildHlslOutputSnapshot(Mat, NewCustomNode, OutputsOut);
 
         ResultJson->SetBoolField(TEXT("success"), true);
         ResultJson->SetBoolField(TEXT("hlsl_updated"), bHasHlsl);
         ResultJson->SetBoolField(TEXT("parameters_updated"), bHasParameters);
+        ResultJson->SetBoolField(TEXT("outputs_updated"), bHasOutputs);
         ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(NewCustomNode));
         ResultJson->SetArrayField(TEXT("parameters"), ParametersOut);
+        ResultJson->SetArrayField(TEXT("outputs"), OutputsOut);
+        ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, NewCustomNode));
+    }
+    else if (CommandType == TEXT("hlsl_delete"))
+    {
+        UMaterial* Mat = Subsystem->GetTargetMaterial();
+        UMaterialExpressionCustom* CustomNode = nullptr;
+        FString ValidationReason;
+        if (!IsValidHlslTarget(Mat, CustomNode, ValidationReason))
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Target is not HLSL-protocol ready: %s. Call hlsl_set_target first."), *ValidationReason));
+            return ResultJson;
+        }
+
+        bool bConfirmDelete = false;
+        Params->TryGetBoolField(TEXT("confirm_delete"), bConfirmDelete);
+        if (!bConfirmDelete)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetBoolField(TEXT("requires_confirmation"), true);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Deletion requires confirm_delete=true."));
+            return ResultJson;
+        }
+
+        FString Kind;
+        Params->TryGetStringField(TEXT("kind"), Kind);
+        const FString KindKey = NormalizeMaterialToken(Kind);
+        const bool bRestrictParameter = KindKey == TEXT("parameter") || KindKey == TEXT("param") || KindKey == TEXT("input");
+        const bool bRestrictOutput = KindKey == TEXT("output");
+        if (!KindKey.IsEmpty() && !bRestrictParameter && !bRestrictOutput)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("'kind' must be 'parameter' or 'output' when provided."));
+            return ResultJson;
+        }
+
+        TArray<FString> NamesToDelete;
+        FString SingleName;
+        if (Params->TryGetStringField(TEXT("name"), SingleName) && !SingleName.IsEmpty())
+        {
+            NamesToDelete.Add(SingleName);
+        }
+
+        const TArray<TSharedPtr<FJsonValue>>* NamesArray = nullptr;
+        if (Params->TryGetArrayField(TEXT("names"), NamesArray))
+        {
+            for (const TSharedPtr<FJsonValue>& NameVal : *NamesArray)
+            {
+                if (NameVal.IsValid())
+                {
+                    FString Name = NameVal->AsString();
+                    if (!Name.IsEmpty())
+                    {
+                        NamesToDelete.AddUnique(Name);
+                    }
+                }
+            }
+        }
+
+        if (NamesToDelete.Num() == 0)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Provide 'name' or 'names' to delete."));
+            return ResultJson;
+        }
+
+        TArray<FString> ParameterNamesToDelete;
+        TArray<FString> OutputNamesToDelete;
+        TArray<TSharedPtr<FJsonValue>> AmbiguousCandidates;
+
+        for (const FString& RequestedName : NamesToDelete)
+        {
+            TArray<FString> ParameterMatches;
+            TArray<FString> OutputMatches;
+
+            if (!bRestrictOutput)
+            {
+                for (const FCustomInput& Input : CustomNode->Inputs)
+                {
+                    const FString InputName = Input.InputName.ToString();
+                    if (InputName.Equals(RequestedName, ESearchCase::IgnoreCase))
+                    {
+                        ParameterMatches.Add(InputName);
+                    }
+                }
+            }
+
+            if (!bRestrictParameter)
+            {
+                const FString RequestedTarget = ResolveMaterialOutputTarget(RequestedName);
+                for (int32 i = 0; i < CustomNode->AdditionalOutputs.Num(); ++i)
+                {
+                    const FCustomOutput& Existing = CustomNode->AdditionalOutputs[i];
+                    const FString OutputName = Existing.OutputName.ToString();
+                    const FString ConnectedTarget = FindConnectedTargetForCustomOutput(Mat, CustomNode, i + 1);
+                    const FString OutputTarget = ConnectedTarget.IsEmpty() ? ResolveMaterialOutputTarget(OutputName) : ConnectedTarget;
+                    if (OutputName.Equals(RequestedName, ESearchCase::IgnoreCase) ||
+                        OutputTarget.Equals(RequestedTarget, ESearchCase::IgnoreCase))
+                    {
+                        OutputMatches.Add(OutputName);
+                    }
+                }
+            }
+
+            const int32 MatchCount = ParameterMatches.Num() + OutputMatches.Num();
+            if (MatchCount == 0)
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("No HLSL parameter or output found for '%s'."), *RequestedName));
+                return ResultJson;
+            }
+
+            if (MatchCount > 1)
+            {
+                TSharedPtr<FJsonObject> CandidateObj = MakeShareable(new FJsonObject);
+                CandidateObj->SetStringField(TEXT("name"), RequestedName);
+                TArray<TSharedPtr<FJsonValue>> CandidateKinds;
+                for (const FString& ParameterName : ParameterMatches)
+                {
+                    TSharedPtr<FJsonObject> Item = MakeShareable(new FJsonObject);
+                    Item->SetStringField(TEXT("kind"), TEXT("parameter"));
+                    Item->SetStringField(TEXT("name"), ParameterName);
+                    CandidateKinds.Add(MakeShareable(new FJsonValueObject(Item)));
+                }
+                for (const FString& OutputName : OutputMatches)
+                {
+                    TSharedPtr<FJsonObject> Item = MakeShareable(new FJsonObject);
+                    Item->SetStringField(TEXT("kind"), TEXT("output"));
+                    Item->SetStringField(TEXT("name"), OutputName);
+                    CandidateKinds.Add(MakeShareable(new FJsonValueObject(Item)));
+                }
+                CandidateObj->SetArrayField(TEXT("candidates"), CandidateKinds);
+                AmbiguousCandidates.Add(MakeShareable(new FJsonValueObject(CandidateObj)));
+                continue;
+            }
+
+            if (ParameterMatches.Num() == 1)
+            {
+                ParameterNamesToDelete.AddUnique(ParameterMatches[0]);
+            }
+            if (OutputMatches.Num() == 1)
+            {
+                OutputNamesToDelete.AddUnique(OutputMatches[0]);
+            }
+        }
+
+        if (AmbiguousCandidates.Num() > 0)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetBoolField(TEXT("requires_kind"), true);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Delete target is ambiguous. Provide kind='parameter' or kind='output'."));
+            ResultJson->SetArrayField(TEXT("ambiguous"), AmbiguousCandidates);
+            return ResultJson;
+        }
+
+        TArray<FString> DeletedParameters;
+        TArray<FString> ParameterNodeHandlesToDelete;
+        TArray<FHlslParamDraft> ParametersToReconnect;
+        if (ParameterNamesToDelete.Num() > 0)
+        {
+            TArray<FString> FinalInputNames;
+            for (const FCustomInput& Input : CustomNode->Inputs)
+            {
+                const FString InputName = Input.InputName.ToString();
+                UMaterialExpression* SourceExpr = Input.Input.Expression;
+                const bool bDeleteThis = ParameterNamesToDelete.ContainsByPredicate([&InputName](const FString& Candidate)
+                {
+                    return Candidate.Equals(InputName, ESearchCase::IgnoreCase);
+                });
+
+                if (bDeleteThis)
+                {
+                    DeletedParameters.Add(InputName);
+                    if (SourceExpr &&
+                        (Cast<UMaterialExpressionScalarParameter>(SourceExpr) ||
+                         Cast<UMaterialExpressionVectorParameter>(SourceExpr) ||
+                         Cast<UMaterialExpressionTextureSampleParameter>(SourceExpr)))
+                    {
+                        ParameterNodeHandlesToDelete.AddUnique(ResolveHandleFromExpression(SourceExpr));
+                    }
+                }
+                else
+                {
+                    FinalInputNames.Add(InputName);
+                    FHlslParamDraft KeptParam;
+                    KeptParam.Name = InputName;
+                    KeptParam.Kind = DetectParamKind(SourceExpr);
+                    ParametersToReconnect.Add(KeptParam);
+                }
+            }
+
+            if (!Subsystem->SetCustomNodeHLSL(CustomNode->GetName(), CustomNode->Code, FinalInputNames))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), TEXT("Failed to remove HLSL parameter inputs."));
+                return ResultJson;
+            }
+
+            for (const FString& Handle : ParameterNodeHandlesToDelete)
+            {
+                if (!Handle.IsEmpty())
+                {
+                    Subsystem->DeleteNode(Handle);
+                }
+            }
+
+            for (const FHlslParamDraft& Param : ParametersToReconnect)
+            {
+                const FString ParamKind = Param.Kind.IsEmpty() || Param.Kind.Equals(UnknownParamKind, ESearchCase::IgnoreCase) ? DefaultParamKind : Param.Kind;
+                const FString ParamHandle = Subsystem->DefineVariable(Param.Name, ParamKind);
+                if (IsErrorStatus(ParamHandle))
+                {
+                    ResultJson->SetBoolField(TEXT("success"), false);
+                    ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to reconnect HLSL parameter '%s': %s"), *Param.Name, *ParamHandle));
+                    return ResultJson;
+                }
+                if (!Subsystem->ConnectPins(ParamHandle, TEXT(""), CustomNode->GetName(), Param.Name))
+                {
+                    ResultJson->SetBoolField(TEXT("success"), false);
+                    ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to reconnect HLSL parameter '%s'."), *Param.Name));
+                    return ResultJson;
+                }
+            }
+            CustomNode = FindSingleCustomNode(Subsystem->GetTargetMaterial());
+        }
+
+        TArray<FString> DeletedOutputs;
+        if (OutputNamesToDelete.Num() > 0)
+        {
+            FString DeleteOutputError;
+            if (!DeleteHlslOutputs(Subsystem, Mat, CustomNode, OutputNamesToDelete, DeletedOutputs, DeleteOutputError))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), DeleteOutputError);
+                return ResultJson;
+            }
+            CustomNode = FindSingleCustomNode(Subsystem->GetTargetMaterial());
+        }
+
+        TArray<TSharedPtr<FJsonValue>> DeletedJson;
+        for (const FString& DeletedParameter : DeletedParameters)
+        {
+            TSharedPtr<FJsonObject> Item = MakeShareable(new FJsonObject);
+            Item->SetStringField(TEXT("kind"), TEXT("parameter"));
+            Item->SetStringField(TEXT("name"), DeletedParameter);
+            DeletedJson.Add(MakeShareable(new FJsonValueObject(Item)));
+        }
+        for (const FString& DeletedOutput : DeletedOutputs)
+        {
+            TSharedPtr<FJsonObject> Item = MakeShareable(new FJsonObject);
+            Item->SetStringField(TEXT("kind"), TEXT("output"));
+            Item->SetStringField(TEXT("name"), DeletedOutput);
+            DeletedJson.Add(MakeShareable(new FJsonValueObject(Item)));
+        }
+
+        TArray<TSharedPtr<FJsonValue>> ParametersOut;
+        BuildParameterSnapshot(CustomNode, ParametersOut);
+        TArray<TSharedPtr<FJsonValue>> OutputsOut;
+        BuildHlslOutputSnapshot(Mat, CustomNode, OutputsOut);
+
+        ResultJson->SetBoolField(TEXT("success"), true);
+        ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(CustomNode));
+        ResultJson->SetArrayField(TEXT("deleted"), DeletedJson);
+        ResultJson->SetArrayField(TEXT("parameters"), ParametersOut);
+        ResultJson->SetArrayField(TEXT("outputs"), OutputsOut);
+        ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, CustomNode));
+    }
+    else if (CommandType == TEXT("hlsl_delete_parameter"))
+    {
+        UMaterial* Mat = Subsystem->GetTargetMaterial();
+        UMaterialExpressionCustom* CustomNode = nullptr;
+        FString ValidationReason;
+        if (!IsValidHlslTarget(Mat, CustomNode, ValidationReason))
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Target is not HLSL-protocol ready: %s. Call hlsl_set_target first."), *ValidationReason));
+            return ResultJson;
+        }
+
+        bool bConfirmDelete = false;
+        Params->TryGetBoolField(TEXT("confirm_delete"), bConfirmDelete);
+
+        TArray<FString> NamesToDelete;
+        FString SingleName;
+        if (Params->TryGetStringField(TEXT("name"), SingleName) && !SingleName.IsEmpty())
+        {
+            NamesToDelete.Add(SingleName);
+        }
+
+        const TArray<TSharedPtr<FJsonValue>>* NamesArray = nullptr;
+        if (Params->TryGetArrayField(TEXT("names"), NamesArray))
+        {
+            for (const TSharedPtr<FJsonValue>& NameVal : *NamesArray)
+            {
+                if (NameVal.IsValid())
+                {
+                    FString Name = NameVal->AsString();
+                    if (!Name.IsEmpty())
+                    {
+                        NamesToDelete.AddUnique(Name);
+                    }
+                }
+            }
+        }
+
+        if (NamesToDelete.Num() == 0)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Provide 'name' or 'names' to delete."));
+            return ResultJson;
+        }
+
+        if (!bConfirmDelete)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetBoolField(TEXT("requires_confirmation"), true);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Deletion requires confirm_delete=true."));
+            return ResultJson;
+        }
+
+        TArray<FString> FinalInputNames;
+        TArray<FString> DeletedNames;
+        TArray<FString> ParameterNodeHandlesToDelete;
+        TArray<FHlslParamDraft> ParametersToReconnect;
+        for (const FCustomInput& Input : CustomNode->Inputs)
+        {
+            const FString InputName = Input.InputName.ToString();
+            UMaterialExpression* SourceExpr = Input.Input.Expression;
+            const bool bDeleteThis = NamesToDelete.ContainsByPredicate([&InputName](const FString& Candidate)
+            {
+                return Candidate.Equals(InputName, ESearchCase::IgnoreCase);
+            });
+
+            if (bDeleteThis)
+            {
+                DeletedNames.Add(InputName);
+                if (SourceExpr &&
+                    (Cast<UMaterialExpressionScalarParameter>(SourceExpr) ||
+                     Cast<UMaterialExpressionVectorParameter>(SourceExpr) ||
+                     Cast<UMaterialExpressionTextureSampleParameter>(SourceExpr)))
+                {
+                    ParameterNodeHandlesToDelete.AddUnique(ResolveHandleFromExpression(SourceExpr));
+                }
+            }
+            else
+            {
+                FinalInputNames.Add(InputName);
+                FHlslParamDraft KeptParam;
+                KeptParam.Name = InputName;
+                KeptParam.Kind = DetectParamKind(SourceExpr);
+                ParametersToReconnect.Add(KeptParam);
+            }
+        }
+
+        if (DeletedNames.Num() == 0)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("No matching HLSL parameter found."));
+            return ResultJson;
+        }
+
+        if (!Subsystem->SetCustomNodeHLSL(CustomNode->GetName(), CustomNode->Code, FinalInputNames))
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Failed to remove HLSL parameter inputs."));
+            return ResultJson;
+        }
+
+        for (const FString& Handle : ParameterNodeHandlesToDelete)
+        {
+            if (!Handle.IsEmpty())
+            {
+                Subsystem->DeleteNode(Handle);
+            }
+        }
+
+        for (const FHlslParamDraft& Param : ParametersToReconnect)
+        {
+            const FString ParamKind = Param.Kind.IsEmpty() || Param.Kind.Equals(UnknownParamKind, ESearchCase::IgnoreCase) ? DefaultParamKind : Param.Kind;
+            const FString ParamHandle = Subsystem->DefineVariable(Param.Name, ParamKind);
+            if (IsErrorStatus(ParamHandle))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to reconnect HLSL parameter '%s': %s"), *Param.Name, *ParamHandle));
+                return ResultJson;
+            }
+            if (!Subsystem->ConnectPins(ParamHandle, TEXT(""), CustomNode->GetName(), Param.Name))
+            {
+                ResultJson->SetBoolField(TEXT("success"), false);
+                ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to reconnect HLSL parameter '%s'."), *Param.Name));
+                return ResultJson;
+            }
+        }
+
+        UMaterialExpressionCustom* NewCustomNode = FindSingleCustomNode(Subsystem->GetTargetMaterial());
+        TArray<TSharedPtr<FJsonValue>> ParametersOut;
+        BuildParameterSnapshot(NewCustomNode, ParametersOut);
+
+        TArray<TSharedPtr<FJsonValue>> DeletedJson;
+        for (const FString& DeletedName : DeletedNames)
+        {
+            DeletedJson.Add(MakeShareable(new FJsonValueString(DeletedName)));
+        }
+
+        ResultJson->SetBoolField(TEXT("success"), true);
+        ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(NewCustomNode));
+        ResultJson->SetArrayField(TEXT("deleted_parameters"), DeletedJson);
+        ResultJson->SetArrayField(TEXT("parameters"), ParametersOut);
+        ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, NewCustomNode));
+    }
+    else if (CommandType == TEXT("hlsl_delete_output"))
+    {
+        UMaterial* Mat = Subsystem->GetTargetMaterial();
+        UMaterialExpressionCustom* CustomNode = nullptr;
+        FString ValidationReason;
+        if (!IsValidHlslTarget(Mat, CustomNode, ValidationReason))
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), FString::Printf(TEXT("Target is not HLSL-protocol ready: %s. Call hlsl_set_target first."), *ValidationReason));
+            return ResultJson;
+        }
+
+        bool bConfirmDelete = false;
+        Params->TryGetBoolField(TEXT("confirm_delete"), bConfirmDelete);
+
+        TArray<FString> NamesToDelete;
+        FString SingleName;
+        if (Params->TryGetStringField(TEXT("name"), SingleName) && !SingleName.IsEmpty())
+        {
+            NamesToDelete.Add(SingleName);
+        }
+
+        const TArray<TSharedPtr<FJsonValue>>* NamesArray = nullptr;
+        if (Params->TryGetArrayField(TEXT("names"), NamesArray))
+        {
+            for (const TSharedPtr<FJsonValue>& NameVal : *NamesArray)
+            {
+                if (NameVal.IsValid())
+                {
+                    FString Name = NameVal->AsString();
+                    if (!Name.IsEmpty())
+                    {
+                        NamesToDelete.AddUnique(Name);
+                    }
+                }
+            }
+        }
+
+        if (NamesToDelete.Num() == 0)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Provide 'name' or 'names' to delete."));
+            return ResultJson;
+        }
+
+        if (!bConfirmDelete)
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetBoolField(TEXT("requires_confirmation"), true);
+            ResultJson->SetStringField(TEXT("error"), TEXT("Deletion requires confirm_delete=true."));
+            return ResultJson;
+        }
+
+        TArray<FString> DeletedNames;
+        FString DeleteError;
+        if (!DeleteHlslOutputs(Subsystem, Mat, CustomNode, NamesToDelete, DeletedNames, DeleteError))
+        {
+            ResultJson->SetBoolField(TEXT("success"), false);
+            ResultJson->SetStringField(TEXT("error"), DeleteError);
+            return ResultJson;
+        }
+
+        UMaterialExpressionCustom* NewCustomNode = FindSingleCustomNode(Subsystem->GetTargetMaterial());
+        TArray<TSharedPtr<FJsonValue>> DeletedJson;
+        for (const FString& DeletedName : DeletedNames)
+        {
+            DeletedJson.Add(MakeShareable(new FJsonValueString(DeletedName)));
+        }
+
+        TArray<TSharedPtr<FJsonValue>> OutputsOut;
+        BuildHlslOutputSnapshot(Mat, NewCustomNode, OutputsOut);
+
+        ResultJson->SetBoolField(TEXT("success"), true);
+        ResultJson->SetStringField(TEXT("custom_node_handle"), ResolveHandleFromExpression(NewCustomNode));
+        ResultJson->SetArrayField(TEXT("deleted_outputs"), DeletedJson);
+        ResultJson->SetArrayField(TEXT("outputs"), OutputsOut);
+        ResultJson->SetObjectField(TEXT("output_contract"), BuildOutputContract(Mat, NewCustomNode));
     }
     else if (CommandType == TEXT("hlsl_compile"))
     {

--- a/Source/UmgMcp/Private/Material/UmgMcpMaterialSubsystem.cpp
+++ b/Source/UmgMcp/Private/Material/UmgMcpMaterialSubsystem.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "Material/UmgMcpMaterialSubsystem.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Factories/MaterialFactoryNew.h"
 #include "Materials/Material.h"
@@ -115,7 +116,7 @@ FString UUmgMcpMaterialSubsystem::SetTargetMaterial(const FString& AssetPath, bo
         if (NewMat)
         {
             // Set Default Config for UMG
-            NewMat->MaterialDomain = MD_UI;
+            NewMat->MaterialDomain = EMaterialDomain::MD_UI;
             NewMat->BlendMode = BLEND_Translucent;
             
             FAssetRegistryModule::AssetCreated(NewMat);
@@ -319,7 +320,7 @@ FExpressionInput* FindInputProperty(UObject* Owner, const FString& PinName)
     {
         if (SearchName.Equals(TEXT("Output"), ESearchCase::IgnoreCase))
         {
-            SearchName = (Mat->MaterialDomain == MD_UI) ? TEXT("EmissiveColor") : TEXT("BaseColor");
+            SearchName = (Mat->MaterialDomain == EMaterialDomain::MD_UI) ? TEXT("EmissiveColor") : TEXT("BaseColor");
         }
         else if (SearchName.Equals(TEXT("FinalColor"), ESearchCase::IgnoreCase) || SearchName.Equals(TEXT("最终颜色"), ESearchCase::IgnoreCase))
         {
@@ -376,6 +377,27 @@ FExpressionInput* FindInputProperty(UObject* Owner, const FString& PinName)
         }
     }
     return nullptr;
+}
+
+static int32 ResolveExpressionOutputIndex(UMaterialExpression* Expression, const FString& PinName)
+{
+    if (!Expression || PinName.IsEmpty() || PinName.Equals(TEXT("Output"), ESearchCase::IgnoreCase))
+    {
+        return 0;
+    }
+
+    if (UMaterialExpressionCustom* CustomNode = Cast<UMaterialExpressionCustom>(Expression))
+    {
+        for (int32 i = 0; i < CustomNode->AdditionalOutputs.Num(); ++i)
+        {
+            if (CustomNode->AdditionalOutputs[i].OutputName.ToString().Equals(PinName, ESearchCase::IgnoreCase))
+            {
+                return i + 1;
+            }
+        }
+    }
+
+    return 0;
 }
 
 bool UUmgMcpMaterialSubsystem::ConnectNodes(const FString& FromHandle, const FString& ToHandle)
@@ -453,27 +475,42 @@ bool UUmgMcpMaterialSubsystem::ConnectPins(const FString& FromHandle, const FStr
 
         // 3. Find Output Pin on Source
         UEdGraphPin* SourcePin = nullptr;
+        int32 SourceOutputIndex = 0;
         if (FromPin.IsEmpty() || FromPin.Equals(TEXT("Output"), ESearchCase::IgnoreCase))
         {
             // If empty or named "Output", take the first output pin found
+            int32 OutputIndex = 0;
             for (UEdGraphPin* Pin : SourceGraphNode->Pins)
             {
+                if (Pin->Direction != EGPD_Output)
+                {
+                    continue;
+                }
                 if (Pin->Direction == EGPD_Output)
                 {
                     SourcePin = Pin;
+                    SourceOutputIndex = OutputIndex;
                     break;
                 }
+                ++OutputIndex;
             }
         }
         else
         {
+            int32 OutputIndex = 0;
             for (UEdGraphPin* Pin : SourceGraphNode->Pins)
             {
-                if (Pin->Direction == EGPD_Output && Pin->PinName.ToString().Equals(FromPin, ESearchCase::IgnoreCase))
+                if (Pin->Direction != EGPD_Output)
+                {
+                    continue;
+                }
+                if (Pin->PinName.ToString().Equals(FromPin, ESearchCase::IgnoreCase))
                 {
                     SourcePin = Pin;
+                    SourceOutputIndex = OutputIndex;
                     break;
                 }
+                ++OutputIndex;
             }
         }
 
@@ -491,7 +528,7 @@ bool UUmgMcpMaterialSubsystem::ConnectPins(const FString& FromHandle, const FStr
         FString CleanPinName = TargetPinName.TrimStartAndEnd().Replace(TEXT(" "), TEXT(""));
         if (CleanPinName.IsEmpty() || CleanPinName.Equals(TEXT("Output"), ESearchCase::IgnoreCase))
         {
-            TargetPinName = (Mat->MaterialDomain == MD_UI) ? TEXT("EmissiveColor") : TEXT("BaseColor");
+            TargetPinName = (Mat->MaterialDomain == EMaterialDomain::MD_UI) ? TEXT("EmissiveColor") : TEXT("BaseColor");
         }
         else if (CleanPinName.Equals(TEXT("FinalColor"), ESearchCase::IgnoreCase) || CleanPinName.Equals(TEXT("最终颜色"), ESearchCase::IgnoreCase))
         {
@@ -620,7 +657,7 @@ bool UUmgMcpMaterialSubsystem::ConnectPins(const FString& FromHandle, const FStr
         if (DataInput && SourceGraphNode->MaterialExpression)
         {
             DataInput->Expression = SourceGraphNode->MaterialExpression;
-            DataInput->OutputIndex = 0;
+            DataInput->OutputIndex = SourceOutputIndex;
             UE_LOG(LogTemp, Log, TEXT("[MaterialSubsystem] ConnectPins: Data-layer synced for Root.%s"), *TargetPinName);
         }
 
@@ -643,7 +680,7 @@ bool UUmgMcpMaterialSubsystem::ConnectPins(const FString& FromHandle, const FStr
         if (InputPtr)
         {
             InputPtr->Expression = FromExpr;
-            InputPtr->OutputIndex = 0;
+            InputPtr->OutputIndex = ResolveExpressionOutputIndex(FromExpr, FromPin);
             
             Mat->PostEditChange();
             Mat->MarkPackageDirty();
@@ -707,7 +744,7 @@ bool UUmgMcpMaterialSubsystem::ConnectPins(const FString& FromHandle, const FStr
         if (InputPtr)
         {
             InputPtr->Expression = FromNode;
-            InputPtr->OutputIndex = 0;
+            InputPtr->OutputIndex = ResolveExpressionOutputIndex(FromNode, FromPin);
             
             // UE_LOG(LogTemp, Warning, TEXT("[ConnectPins] Reflection: Connected %s -> %s"), *FromHandle, *ToHandle);
             
@@ -787,7 +824,7 @@ bool UUmgMcpMaterialSubsystem::SetNodeProperties(const FString& NodeHandle, cons
     // Use Reflection to apply properties
     for (const auto& Elem : Properties->Values)
     {
-        FString PropName = Elem.Key;
+        FString PropName = UmgMcpJsonCompat::KeyToString(Elem.Key);
         TSharedPtr<FJsonValue> JsonVal = Elem.Value;
         
         FProperty* Prop = TargetObject->GetClass()->FindPropertyByName(*PropName);
@@ -969,7 +1006,7 @@ bool UUmgMcpMaterialSubsystem::SetOutputNode(const FString& NodeHandle)
         }
 
         // Also try to connect to Opacity if available (for translucent UI materials)
-        if (bSuccess && Mat->MaterialDomain == MD_UI)
+        if (bSuccess && Mat->MaterialDomain == EMaterialDomain::MD_UI)
         {
             for (UEdGraphPin* Pin : RootNode->Pins)
             {

--- a/Source/UmgMcp/Private/Widget/UmgMcpWidgetCommands.cpp
+++ b/Source/UmgMcp/Private/Widget/UmgMcpWidgetCommands.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "Widget/UmgMcpWidgetCommands.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "Bridge/UmgMcpCommonUtils.h"
 #include "Widget/UmgGetSubsystem.h"
 #include "Widget/UmgSetSubsystem.h"
@@ -75,7 +76,7 @@ TSharedPtr<FJsonObject> FUmgMcpWidgetCommands::HandleCommand(const FString& Comm
                 Response->SetBoolField(TEXT("success"), true);
                 for (const auto& Field : QueriedProperties->Values)
                 {
-                    Response->SetField(Field.Key, Field.Value);
+                    Response->SetField(UmgMcpJsonCompat::KeyToString(Field.Key), Field.Value);
                 }
             }
             else
@@ -104,7 +105,7 @@ TSharedPtr<FJsonObject> FUmgMcpWidgetCommands::HandleCommand(const FString& Comm
                 Response->SetBoolField(TEXT("success"), true);
                 for (const auto& Field : SchemaJson->Values)
                 {
-                    Response->SetField(Field.Key, Field.Value);
+                    Response->SetField(UmgMcpJsonCompat::KeyToString(Field.Key), Field.Value);
                 }
             }
             else

--- a/Source/UmgMcp/Private/Widget/UmgSetSubsystem.cpp
+++ b/Source/UmgMcp/Private/Widget/UmgSetSubsystem.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 
 #include "Widget/UmgSetSubsystem.h"
+#include "Bridge/UmgMcpJsonCompat.h"
 #include "FileManage/UmgAttentionSubsystem.h"
 #include "Editor.h"
 #include "WidgetBlueprint.h"
@@ -66,7 +67,16 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
     
     // 2. Extract and expand aliases in NormalizedProperties
     TArray<FString> CurrentKeys;
-    NormalizedProperties->Values.GetKeys(CurrentKeys);
+    auto RefreshCurrentKeys = [&CurrentKeys, &NormalizedProperties]()
+    {
+        CurrentKeys.Reset();
+        for (const auto& Field : NormalizedProperties->Values)
+        {
+            CurrentKeys.Add(UmgMcpJsonCompat::KeyToString(Field.Key));
+        }
+    };
+
+    RefreshCurrentKeys();
     for (const FString& Key : CurrentKeys)
     {
         if (Key.StartsWith(TEXT("Slot."), ESearchCase::IgnoreCase))
@@ -95,7 +105,8 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
             // [智能反射匹配失败]：安全降级，进入 Canvas 别名处理层判断
             if (Key.Equals(TEXT("Slot.Position"), ESearchCase::IgnoreCase))
             {
-                TSharedPtr<FJsonValue> Val = NormalizedProperties->Values[Key];
+                TSharedPtr<FJsonValue> Val = NormalizedProperties->TryGetField(Key);
+                if (!Val.IsValid()) continue;
                 if (Val->Type == EJson::Array && Val->AsArray().Num() >= 2) {
                     NormalizedProperties->SetField(TEXT("Slot.LayoutData.Offsets.Left"), Val->AsArray()[0]);
                     NormalizedProperties->SetField(TEXT("Slot.LayoutData.Offsets.Top"), Val->AsArray()[1]);
@@ -104,7 +115,8 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
             }
             else if (Key.Equals(TEXT("Slot.Size"), ESearchCase::IgnoreCase))
             {
-                TSharedPtr<FJsonValue> Val = NormalizedProperties->Values[Key];
+                TSharedPtr<FJsonValue> Val = NormalizedProperties->TryGetField(Key);
+                if (!Val.IsValid()) continue;
                 if (Val->Type == EJson::Array && Val->AsArray().Num() >= 2) {
                     NormalizedProperties->SetField(TEXT("Slot.LayoutData.Offsets.Right"), Val->AsArray()[0]);
                     NormalizedProperties->SetField(TEXT("Slot.LayoutData.Offsets.Bottom"), Val->AsArray()[1]);
@@ -113,12 +125,16 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
             }
             else if (Key.Equals(TEXT("Slot.Anchors"), ESearchCase::IgnoreCase))
             {
-                NormalizedProperties->SetField(TEXT("Slot.LayoutData.Anchors"), NormalizedProperties->Values[Key]);
+                TSharedPtr<FJsonValue> Val = NormalizedProperties->TryGetField(Key);
+                if (!Val.IsValid()) continue;
+                NormalizedProperties->SetField(TEXT("Slot.LayoutData.Anchors"), Val);
                 NormalizedProperties->RemoveField(Key);
             }
             else if (Key.Equals(TEXT("Slot.Alignment"), ESearchCase::IgnoreCase))
             {
-                NormalizedProperties->SetField(TEXT("Slot.LayoutData.Alignment"), NormalizedProperties->Values[Key]);
+                TSharedPtr<FJsonValue> Val = NormalizedProperties->TryGetField(Key);
+                if (!Val.IsValid()) continue;
+                NormalizedProperties->SetField(TEXT("Slot.LayoutData.Alignment"), Val);
                 NormalizedProperties->RemoveField(Key);
             }
         }
@@ -133,7 +149,7 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
     }
 
     // Re-scan for any dotted keys (including expanded aliases)
-    NormalizedProperties->Values.GetKeys(CurrentKeys);
+    RefreshCurrentKeys();
     for (const FString& FullKey : CurrentKeys)
     {
         if (FullKey.Contains(TEXT(".")))
@@ -163,7 +179,9 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
                     TargetObj = ConstCastSharedPtr<FJsonObject>(*ExistingObj);
                 }
             }
-            TargetObj->SetField(Parts.Last(), NormalizedProperties->Values[FullKey]);
+            TSharedPtr<FJsonValue> Val = NormalizedProperties->TryGetField(FullKey);
+            if (!Val.IsValid()) continue;
+            TargetObj->SetField(Parts.Last(), Val);
             NormalizedProperties->RemoveField(FullKey);
         }
     }
@@ -212,7 +230,8 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
     {
         for (const auto& Pair : NormalizedProperties->Values)
         {
-            FProperty* Prop = FoundWidget->GetClass()->FindPropertyByName(FName(*Pair.Key));
+            const FString PropertyName = UmgMcpJsonCompat::KeyToString(Pair.Key);
+            FProperty* Prop = FoundWidget->GetClass()->FindPropertyByName(FName(*PropertyName));
             if (!Prop) continue;
 
             // SPECIAL CASE: Auto-resolve Object Pointers from paths
@@ -232,7 +251,7 @@ bool UUmgSetSubsystem::SetWidgetProperties(UWidgetBlueprint* WidgetBlueprint, co
 
             // Fallback: Use standard converter for this specific field
             TSharedPtr<FJsonObject> SinglePropJson = MakeShared<FJsonObject>();
-            SinglePropJson->SetField(Pair.Key, Pair.Value);
+            SinglePropJson->SetField(PropertyName, Pair.Value);
             FJsonObjectConverter::JsonObjectToUStruct(SinglePropJson.ToSharedRef(), FoundWidget->GetClass(), FoundWidget, 0, 0);
         }
     }

--- a/Source/UmgMcp/Public/Bridge/UmgMcpJsonCompat.h
+++ b/Source/UmgMcp/Public/Bridge/UmgMcpJsonCompat.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2025-2026 Winyunq. All rights reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+#include "Containers/SharedString.h"
+#endif
+
+namespace UmgMcpJsonCompat
+{
+	inline FString KeyToString(const FString& Key)
+	{
+		return Key;
+	}
+
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+	inline FString KeyToString(const UE::FSharedString& Key)
+	{
+		return FString(Key.ToView());
+	}
+#endif
+}

--- a/Source/UmgMcp/Public/Material/UmgMcpMaterialSubsystem.h
+++ b/Source/UmgMcp/Public/Material/UmgMcpMaterialSubsystem.h
@@ -10,7 +10,7 @@
 /**
  * @brief       UMGMCP 材质操控子系统
  * 
- * 本子系统作为 MCP 5 Pillars 战略的核心状态机和 API 提供者，
+ * 本子系统作为 Material MCP 的核心状态机和 API 提供者，
  * 负责管理当前编辑上下文 (Target Material) 并提供节点操作、连接和属性设置的原子操作。
  */
 UCLASS()

--- a/UmgMcp.uplugin
+++ b/UmgMcp.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://github.com/winyunq/UnrealMotionGraphicsMCP",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.6.0",
+	"EngineVersion": "5.8.0",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
## Summary
- simplify the Material MCP surface around the HLSL loop: target/get/set/delete/compile
- add UE 5.8 material type fields, semantic output contracts, AdditionalOutputs support, and explicit delete semantics
- add Material ToolMode, protocol documentation, APITest demos/static checks, and a Codex skill
- add UE 5.8 JSON key compatibility for FJsonObject::Values/FSharedString call sites

## Verification
- python -m json.tool Resources/prompts.json
- python -m json.tool Resources/ToolModes/Material.json
- python -m py_compile Resources/Python/UmgMcpServer.py Resources/Python/Material/UMGMaterial.py Resources/Python/APITest/Material_HLSL_Type_Demo.py Resources/Python/APITest/Material_Protocol_Static_Check.py
- python Resources/Python/APITest/Material_Protocol_Static_Check.py
- python C:/Users/winyunq/.codex/skills/.system/skill-creator/scripts/quick_validate.py Skills/umg-material-mcp
- git diff --check
- D:/UE_5.8/Engine/Build/BatchFiles/RunUAT.bat BuildPlugin -Plugin=D:/UE5Project/CLIUMGMCP/plugins/PublicUmgMcp/UmgMcp.uplugin -Package=D:/UE5Project/CLIUMGMCP/BuildPlugin_UmgMcp_codex_20260704_103657 -TargetPlatforms=Win64