### PR TITLE
Add serialized multi-client MCP sessions and debug console

### DIFF
--- a/Document/McpConcurrencyConnectionsDebug_zh.md
+++ b/Document/McpConcurrencyConnectionsDebug_zh.md
@@ -1,0 +1,56 @@
+# MCP 并发、连接隔离与 Debug Console
+
+## 执行模型
+
+TCP 层允许多个客户端同时接入，但所有会修改或读取 UE Editor/UObject 状态的命令都会进入同一个 FIFO 队列，并在 Game Thread 上逐条执行。调用方会阻塞到自己的命令完成，因此不会出现两个 AI 同时改写编辑器状态的情况。
+
+每条请求建议包含：
+
+```json
+{
+  "command": "ping",
+  "client_id": "stable-ai-client-id",
+  "request_id": "unique-request-id",
+  "params": {}
+}
+```
+
+旧客户端不发送 `client_id` 时仍可使用，但会进入共享的 `legacy` 上下文，不具备连接级 target 隔离。
+
+## 多 UE 实例与连接
+
+UE 实例优先监听 `127.0.0.1:55557`。端口被占用时，会绑定由操作系统分配的动态端口，并在项目的 `Saved/UmgMcp/instances` 目录发布发现记录。正常退出时记录会删除；异常退出产生的旧记录应通过 `server_info` 验证。
+
+Python MCP 前端始终提供三个基础工具：
+
+- `list_umg_mcp_servers`：读取本地 UE 实例发现记录。
+- `connect_umg_mcp(host, port, target?, exclusive?)`：把当前 AI 会话绑定到指定 UE 实例，可同时绑定 target。
+- `get_umg_mcp_connection`：查询当前端点、客户端 ID 和 UE 侧连接状态。
+
+也可以通过环境变量指定初始连接：`UMG_MCP_HOST`、`UMG_MCP_PORT`、`UMG_MCP_CLIENT_ID`、`UMG_MCP_CLIENT_NAME`、`UMG_MCP_EXCLUSIVE`、`UMG_MCP_DISCOVERY_DIR`。
+
+## Target 隔离
+
+`connect` 会为 `client_id` 创建会话。未显式传入 target 时，会快照当前 UE 编辑器 target 作为该连接的缺省 target。每条后续命令执行前，桥接层都会恢复该连接自己的以下上下文：
+
+- UMG asset 与 focused widget
+- Blueprint graph、cursor node
+- Animation
+- Material/HLSL material
+
+执行后再把变化写回该连接的会话。缺省 `exclusive=true`；一个连接成功采用 target 后，其他连接尝试采用同一 target 会收到 `code: "target_locked"`，而不会覆盖前者。`disconnect` 会释放该连接持有的租约。
+
+底层协议还支持 `connect`、`disconnect`、`server_info` 和 `list_connections` 命令。
+
+## Debug Console
+
+在 UE 的 **Tools → UMG MCP Debug Console** 打开调试窗口；Widget Blueprint 工具栏也有 **MCP Debug** 按钮。
+
+左侧可输入 AI 实际发送的完整 JSON，点击“按真实管线执行”。消息不会走测试旁路，而是进入与 TCP 请求相同的连接、target 恢复、租约验证和命令执行路径。窗口显示：
+
+- 全局 FIFO 序号及 queued/completed/error 状态
+- client ID、request ID、command
+- 原始请求、完整响应与执行耗时
+- 当前 server instance ID 和实际监听端口
+
+第一次用 `debug-ui` 客户端模拟时，先执行面板提供的“连接模板”，再执行 Ping 或编辑命令。

--- a/Resources/Python/UmgMcpServer.py
+++ b/Resources/Python/UmgMcpServer.py
@@ -23,6 +23,8 @@ import logging
 import asyncio
 import json
 import os
+import uuid
+from pathlib import Path
 
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Dict, Any, Optional, List
@@ -62,26 +64,75 @@ def debug_socket(message: str) -> None:
 class UnrealConnection:
     """Manages the async socket connection to the UmgMcp plugin running inside Unreal Engine."""
     def __init__(self):
-        logger.info(f"Unreal Motion Graphics UI Designer Mode Context Process Launching... Connecting to UmgMcp plugin at {UNREAL_HOST}:{UNREAL_PORT}...")
+        self.host = os.environ.get("UMG_MCP_HOST", UNREAL_HOST)
+        self.port = int(os.environ.get("UMG_MCP_PORT", UNREAL_PORT))
+        self.client_id = os.environ.get("UMG_MCP_CLIENT_ID", str(uuid.uuid4()))
+        self.display_name = os.environ.get("UMG_MCP_CLIENT_NAME", f"AI-{self.client_id[:8]}")
+        self.exclusive = os.environ.get("UMG_MCP_EXCLUSIVE", "true").lower() not in ("0", "false", "no")
+        self._connected = False
+        self._command_lock = asyncio.Lock()
+        logger.info(f"Unreal Motion Graphics UI Designer Mode Context Process Launching... Connecting to UmgMcp plugin at {self.host}:{self.port} as {self.client_id}...")
 
     def disconnect(self) -> None:
         """Short-lived socket connections are closed per command."""
         return None
+
+    async def connect_to(self, host: str, port: int, target: Optional[str] = None,
+                         exclusive: bool = True, display_name: Optional[str] = None) -> Dict[str, Any]:
+        """Atomically move this AI session to a selected UE editor instance."""
+        async with self._command_lock:
+            if self._connected:
+                await self._send_command_unlocked("disconnect", {})
+            self.host = host
+            self.port = int(port)
+            self.exclusive = exclusive
+            if display_name:
+                self.display_name = display_name
+            payload = {
+                "display_name": self.display_name,
+                "exclusive": self.exclusive,
+            }
+            if target:
+                payload["target"] = target
+            response = await self._send_command_unlocked("connect", payload)
+            self._connected = bool(response and response.get("status") != "error")
+            return response
     
     async def send_command(self, command: str, params: Dict[str, Any] = None) -> Optional[Dict[str, Any]]:
         """Send a command to Unreal Engine and get the response (Async Short-Lived)."""
+        async with self._command_lock:
+            if command != "connect" and not self._connected:
+                connected = await self._send_command_unlocked("connect", {
+                    "display_name": self.display_name,
+                    "exclusive": self.exclusive,
+                })
+                if not connected or connected.get("status") == "error":
+                    return connected or {"status": "error", "error": "Unable to establish an UmgMcp session"}
+                self._connected = True
+            response = await self._send_command_unlocked(command, params)
+            if command == "connect" and response and response.get("status") != "error":
+                self._connected = True
+            elif command == "disconnect":
+                self._connected = False
+            return response
+
+    async def _send_command_unlocked(self, command: str, params: Dict[str, Any] = None) -> Optional[Dict[str, Any]]:
+        """Wire-level request. Caller holds _command_lock so request order is deterministic."""
         reader = None
         writer = None
         
         try:
-            logger.info(f"Connecting to Unreal at {UNREAL_HOST}:{UNREAL_PORT}...")
+            logger.info(f"Connecting to Unreal at {self.host}:{self.port}...")
             # Async Open Connection (IOCP on Windows)
-            reader, writer = await asyncio.open_connection(UNREAL_HOST, UNREAL_PORT)
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port), timeout=SOCKET_TIMEOUT)
             
             # Match Unity's command format exactly
             command_obj = {
                 "command": command,
-                "params": params or {}
+                "params": params or {},
+                "client_id": self.client_id,
+                "request_id": str(uuid.uuid4())
             }
             
             # Send with null delimiter
@@ -107,7 +158,7 @@ class UnrealConnection:
             chunks = []
             while True:
                 # Read chunk
-                chunk = await reader.read(4096)
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=max(SOCKET_TIMEOUT, 30))
                 if not chunk:
                     break # EOF
                 
@@ -296,6 +347,64 @@ def register_tool(name: str, default_desc: str):
             # Do not register, just return the function
             return func
     return decorator
+
+
+def _discover_instance_records() -> List[Dict[str, Any]]:
+    """Read discovery records published by local UE editors."""
+    candidates: List[Path] = []
+    configured = os.environ.get("UMG_MCP_DISCOVERY_DIR")
+    if configured:
+        candidates.append(Path(configured))
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if any(parent.glob("*.uproject")):
+            candidates.append(parent / "Saved" / "UmgMcp" / "instances")
+            break
+
+    records: List[Dict[str, Any]] = []
+    seen = set()
+    for directory in candidates:
+        if not directory.exists():
+            continue
+        for record_file in directory.glob("*.json"):
+            try:
+                record = json.loads(record_file.read_text(encoding="utf-8"))
+                key = record.get("server_instance_id") or str(record_file)
+                if key not in seen:
+                    record["discovery_file"] = str(record_file)
+                    records.append(record)
+                    seen.add(key)
+            except (OSError, ValueError) as exc:
+                logger.warning("Ignoring invalid UmgMcp discovery record %s: %s", record_file, exc)
+    return records
+
+
+@mcp.tool(name="list_umg_mcp_servers", description="Lists local UE editor UmgMcp instances available for an explicit connection.")
+async def list_umg_mcp_servers() -> Dict[str, Any]:
+    return {"status": "success", "servers": _discover_instance_records()}
+
+
+@mcp.tool(name="connect_umg_mcp", description="Connects this AI to one UE UmgMcp endpoint and optionally binds an exclusive target.")
+async def connect_umg_mcp(host: str = "127.0.0.1", port: int = UNREAL_PORT,
+                          target: Optional[str] = None, exclusive: bool = True,
+                          display_name: Optional[str] = None) -> Dict[str, Any]:
+    conn = get_unreal_connection()
+    response = await conn.connect_to(host, port, target, exclusive, display_name)
+    if response.get("status") != "error" and target:
+        target_response = await conn.send_command("set_target_umg_asset", {"asset_path": target})
+        if target_response.get("status") == "error":
+            return target_response
+        context_manager.set_target(target)
+        response["target"] = target
+    return response
+
+
+@mcp.tool(name="get_umg_mcp_connection", description="Shows this AI's active UE endpoint, session id, and server-side connection state.")
+async def get_umg_mcp_connection() -> Dict[str, Any]:
+    conn = get_unreal_connection()
+    state = await conn.send_command("server_info", {})
+    state.update({"host": conn.host, "port": conn.port, "client_id": conn.client_id})
+    return state
 
 # =============================================================================
 #  Category: Introspection (Knowledge Base)

--- a/Source/UmgMcp/Private/Bridge/MCPServerRunnable.cpp
+++ b/Source/UmgMcp/Private/Bridge/MCPServerRunnable.cpp
@@ -12,11 +12,14 @@
 #include "JsonObjectConverter.h"
 #include "Misc/ScopeLock.h"
 #include "HAL/PlatformTime.h"
+#include "Async/Async.h"
+#include "Misc/ScopeLock.h"
 
 FMCPServerRunnable::FMCPServerRunnable(UUmgMcpBridge* InBridge, TSharedPtr<FSocket> InListenerSocket)
     : Bridge(InBridge)
     , ListenerSocket(InListenerSocket)
     , bRunning(true)
+    , ActiveConnectionCount(0)
 {
     // UE_LOG(LogUmgMcp, Display, TEXT("MCPServerRunnable: Created server runnable"));
 }
@@ -44,13 +47,35 @@ uint32 FMCPServerRunnable::Run()
         {
             // UE_LOG(LogUmgMcp, Display, TEXT("MCPServerRunnable: Client connection pending, accepting..."));
             
-            ClientSocket = MakeShareable(ListenerSocket->Accept(TEXT("MCPClient")));
+            ClientSocket = MakeShareable(
+                ListenerSocket->Accept(TEXT("MCPClient")),
+                [](FSocket* Socket)
+                {
+                    if (Socket) ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(Socket);
+                });
             if (ClientSocket.IsValid())
             {
                 // UE_LOG(LogUmgMcp, Display, TEXT("MCPServerRunnable: Client connection accepted"));
                 
-                // Use the robust handler that supports large payloads and delimiters
-                HandleClientConnection(ClientSocket);
+                // Each socket is read on a worker. Commands themselves are still forced through
+                // UUmgMcpBridge's single FIFO, so clients may connect concurrently without ever
+                // mutating editor state concurrently.
+                TSharedPtr<FSocket> AcceptedSocket = ClientSocket;
+                ActiveConnectionCount++;
+                {
+                    FScopeLock Lock(&ActiveSocketsCs);
+                    ActiveSockets.Add(AcceptedSocket);
+                }
+                Async(EAsyncExecution::ThreadPool, [this, AcceptedSocket]()
+                {
+                    HandleClientConnection(AcceptedSocket);
+                    AcceptedSocket->Close();
+                    {
+                        FScopeLock Lock(&ActiveSocketsCs);
+                        ActiveSockets.Remove(AcceptedSocket);
+                    }
+                    ActiveConnectionCount--;
+                });
             }
             else
             {
@@ -69,6 +94,25 @@ uint32 FMCPServerRunnable::Run()
 void FMCPServerRunnable::Stop()
 {
     bRunning = false;
+    TArray<TSharedPtr<FSocket>> SocketsToClose;
+    {
+        FScopeLock Lock(&ActiveSocketsCs);
+        SocketsToClose = ActiveSockets;
+    }
+    for (const TSharedPtr<FSocket>& Socket : SocketsToClose)
+    {
+        if (Socket.IsValid())
+        {
+            Socket->Close();
+        }
+    }
+
+    // The bridge owns this runnable and waits for the server thread before deleting it.
+    // Let short-lived connection workers leave their lambdas first.
+    while (ActiveConnectionCount.Load() > 0)
+    {
+        FPlatformProcess::Sleep(0.001f);
+    }
 }
 
 void FMCPServerRunnable::Exit()
@@ -170,6 +214,8 @@ void FMCPServerRunnable::ProcessMessage(TSharedPtr<FSocket> Client, const FStrin
     
     // Extract command type and parameters using MCP protocol format
     FString CommandType;
+    FString ClientId;
+    FString RequestId;
     TSharedPtr<FJsonObject> Params = MakeShareable(new FJsonObject());
     
     if (!JsonMessage->TryGetStringField(TEXT("command"), CommandType))
@@ -177,6 +223,9 @@ void FMCPServerRunnable::ProcessMessage(TSharedPtr<FSocket> Client, const FStrin
         UE_LOG(LogUmgMcp, Warning, TEXT("MCPServerRunnable: Message missing 'command' field"));
         return;
     }
+
+    JsonMessage->TryGetStringField(TEXT("client_id"), ClientId);
+    JsonMessage->TryGetStringField(TEXT("request_id"), RequestId);
     
     // Parameters are optional in MCP protocol
     if (JsonMessage->HasField(TEXT("params")))
@@ -191,23 +240,30 @@ void FMCPServerRunnable::ProcessMessage(TSharedPtr<FSocket> Client, const FStrin
     // UE_LOG(LogUmgMcp, Display, TEXT("MCPServerRunnable: Executing command: %s"), *CommandType);
     
     // Execute command
-    FString Response = Bridge->ExecuteCommand(CommandType, Params);
+    FString Response = Bridge->ExecuteCommand(CommandType, Params, ClientId, RequestId, Message);
     
     // Send response
-    int32 BytesSent = 0;
-    
     // Convert to UTF8
     FTCHARToUTF8 Utf8Response(*Response);
-    
-    // Send the string content
-    if (Utf8Response.Length() > 0)
+
+    // FSocket::Send may perform a partial write. Keep sending until the complete
+    // response and its frame delimiter are on the wire.
+    int32 Offset = 0;
+    while (Offset < Utf8Response.Length())
     {
-        Client->Send((const uint8*)Utf8Response.Get(), Utf8Response.Length(), BytesSent);
+        int32 BytesSent = 0;
+        if (!Client->Send(reinterpret_cast<const uint8*>(Utf8Response.Get()) + Offset,
+            Utf8Response.Length() - Offset, BytesSent) || BytesSent <= 0)
+        {
+            UE_LOG(LogUmgMcp, Warning, TEXT("MCPServerRunnable: Response send failed after %d/%d bytes."), Offset, Utf8Response.Length());
+            return;
+        }
+        Offset += BytesSent;
     }
-    
-    // Send the null delimiter
+
     uint8 Delimiter = 0;
-    Client->Send(&Delimiter, 1, BytesSent);
+    int32 DelimiterBytesSent = 0;
+    Client->Send(&Delimiter, 1, DelimiterBytesSent);
     
     UE_LOG(LogUmgMcp, Display, TEXT("[UMGMCP-Message] Sent response: %s"), *Response);
 }

--- a/Source/UmgMcp/Private/Bridge/UmgMcpBridge.cpp
+++ b/Source/UmgMcp/Private/Bridge/UmgMcpBridge.cpp
@@ -63,12 +63,32 @@
 #include "Material/UmgMcpMaterialCommands.h" // Add Material Commands
 #include "Blueprint/UmgBlueprintFunctionSubsystem.h"
 #include "FileManage/UmgAttentionSubsystem.h"
+#include "Material/UmgMcpMaterialSubsystem.h"
+#include "Misc/Guid.h"
+#include "Misc/DateTime.h"
+#include "HAL/PlatformTime.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformMisc.h"
 
-
+namespace
+{
+bool IsTargetIndependentCommand(const FString& CommandType)
+{
+    return CommandType == TEXT("ping") ||
+        CommandType == TEXT("get_widget_schema") ||
+        CommandType == TEXT("get_last_edited_umg_asset") ||
+        CommandType == TEXT("get_recently_edited_umg_assets") ||
+        CommandType == TEXT("list_assets");
+}
+}
 
 UUmgMcpBridge::UUmgMcpBridge()
 {
     bCommandQueueProcessing = false;
+    ServerRunnable = nullptr;
+    NextSequence = 0;
+    ServerInstanceId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphensLower);
     AttentionCommands = MakeShared<FUmgMcpAttentionCommands>();
     WidgetCommands = MakeShared<FUmgMcpWidgetCommands>();
     FileTransformationCommands = MakeShared<FUmgMcpFileTransformationCommands>();
@@ -98,6 +118,7 @@ void UUmgMcpBridge::Initialize(FSubsystemCollectionBase& Collection)
     ListenerSocket = nullptr;
     ConnectionSocket = nullptr;
     ServerThread = nullptr;
+    ServerRunnable = nullptr;
     Port = MCP_SERVER_PORT_DEFAULT;
     bCommandQueueProcessing = false;
     FIPv4Address::Parse(MCP_SERVER_HOST_DEFAULT, ServerAddress);
@@ -142,7 +163,12 @@ void UUmgMcpBridge::StartServer()
     }
 
     // Create listener socket
-    TSharedPtr<FSocket> NewListenerSocket = MakeShareable(SocketSubsystem->CreateSocket(NAME_Stream, TEXT("UnrealMCPListener"), false));
+    TSharedPtr<FSocket> NewListenerSocket = MakeShareable(
+        SocketSubsystem->CreateSocket(NAME_Stream, TEXT("UnrealMCPListener"), false),
+        [](FSocket* Socket)
+        {
+            if (Socket) ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(Socket);
+        });
     if (!NewListenerSocket.IsValid())
     {
         UE_LOG(LogUmgMcp, Error, TEXT("UmgMcpBridge: Failed to create listener socket: %s"), SocketSubsystem->GetSocketError(SocketSubsystem->GetLastErrorCode()));
@@ -174,7 +200,18 @@ void UUmgMcpBridge::StartServer()
             UE_LOG(LogUmgMcp, Error, TEXT("UmgMcpBridge: Port %d is already in use by another process."), Port);
         }
         
-        return;
+        // Multiple UE editor instances are a supported topology. If the well-known
+        // default is occupied, ask the OS for an ephemeral port instead of disabling MCP.
+        FIPv4Endpoint DynamicEndpoint(ServerAddress, 0);
+        if (!NewListenerSocket->Bind(*DynamicEndpoint.ToInternetAddr()))
+        {
+            return;
+        }
+
+        TSharedRef<FInternetAddr> BoundAddress = SocketSubsystem->CreateInternetAddr();
+        NewListenerSocket->GetAddress(*BoundAddress);
+        Port = BoundAddress->GetPort();
+        UE_LOG(LogUmgMcp, Warning, TEXT("UmgMcpBridge: Default port unavailable; bound dynamic port %d."), Port);
     }
 
     // Start listening
@@ -192,9 +229,26 @@ void UUmgMcpBridge::StartServer()
     bGlobalServerStarted = true; // Set global flag
     UE_LOG(LogUmgMcp, Display, TEXT("UmgMcpBridge: Server started successfully on %s:%d"), *ServerAddress.ToString(), Port);
 
+    // Publish a small discovery record. Clients validate records with server_info, so a
+    // stale file after a crash is harmless and will be ignored.
+    const FString DiscoveryDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UmgMcp"), TEXT("instances"));
+    IFileManager::Get().MakeDirectory(*DiscoveryDir, true);
+    DiscoveryFilePath = FPaths::Combine(DiscoveryDir, ServerInstanceId + TEXT(".json"));
+    TSharedRef<FJsonObject> Discovery = MakeShared<FJsonObject>();
+    Discovery->SetStringField(TEXT("server_instance_id"), ServerInstanceId);
+    Discovery->SetStringField(TEXT("host"), ServerAddress.ToString());
+    Discovery->SetNumberField(TEXT("port"), Port);
+    Discovery->SetStringField(TEXT("project"), FApp::GetProjectName());
+    Discovery->SetNumberField(TEXT("process_id"), FPlatformProcess::GetCurrentProcessId());
+    Discovery->SetStringField(TEXT("started_at"), FDateTime::UtcNow().ToIso8601());
+    FString DiscoveryJson;
+    FJsonSerializer::Serialize(Discovery, TJsonWriterFactory<>::Create(&DiscoveryJson));
+    FFileHelper::SaveStringToFile(DiscoveryJson, *DiscoveryFilePath);
+
     // Start server thread
+    ServerRunnable = new FMCPServerRunnable(this, ListenerSocket);
     ServerThread = FRunnableThread::Create(
-        new FMCPServerRunnable(this, ListenerSocket),
+        ServerRunnable,
         TEXT("UnrealMCPServerThread"),
         0, TPri_Normal
     );
@@ -217,42 +271,83 @@ void UUmgMcpBridge::StopServer()
 
     bIsRunning = false;
     bGlobalServerStarted = false; // Reset global flag
-    bCommandQueueProcessing = false;
+    {
+        // Deinitialization runs on the Game Thread. Wake every socket worker before
+        // waiting for it, otherwise a worker waiting on a queued editor command could
+        // deadlock editor shutdown.
+        FScopeLock CommandLock(&CommandQueueCs);
+        for (const TSharedPtr<FQueuedBridgeCommand, ESPMode::ThreadSafe>& Pending : CommandQueue)
+        {
+            if (Pending.IsValid())
+            {
+                Pending->Response = MakeErrorResponse(TEXT("UmgMcp server is shutting down."), TEXT("server_stopping"));
+                if (Pending->CompletionEvent) Pending->CompletionEvent->Trigger();
+            }
+        }
+        CommandQueue.Empty();
+        bCommandQueueProcessing = false;
+    }
 
     // Clean up thread
     if (ServerThread)
     {
-        ServerThread->Kill(true);
+        if (ServerRunnable)
+        {
+            ServerRunnable->Stop();
+        }
+        ServerThread->WaitForCompletion();
         delete ServerThread;
         ServerThread = nullptr;
     }
+    delete ServerRunnable;
+    ServerRunnable = nullptr;
 
     // Close sockets
     if (ConnectionSocket.IsValid())
     {
-        ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ConnectionSocket.Get());
+        ConnectionSocket->Close();
         ConnectionSocket.Reset();
     }
 
     if (ListenerSocket.IsValid())
     {
-        ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ListenerSocket.Get());
+        ListenerSocket->Close();
         ListenerSocket.Reset();
+    }
+
+    if (!DiscoveryFilePath.IsEmpty())
+    {
+        IFileManager::Get().Delete(*DiscoveryFilePath, false, true);
+        DiscoveryFilePath.Empty();
     }
 
     UE_LOG(LogUmgMcp, Display, TEXT("UmgMcpBridge: Server stopped"));
 }
 
 // Execute a command received from a client
-FString UUmgMcpBridge::ExecuteCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params)
+FString UUmgMcpBridge::ExecuteCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params,
+    const FString& InClientId, const FString& InRequestId, const FString& RawRequestJson)
 {
     UE_LOG(LogUmgMcp, Display, TEXT("UmgMcpBridge: Received command: %s"), *CommandType);
+
+    if (!bIsRunning && !IsInGameThread())
+    {
+        return MakeErrorResponse(TEXT("UmgMcp server is not running."), TEXT("server_stopped"));
+    }
     
     // If we are already on the GameThread (e.g. internal call or test), execute directly
     if (IsInGameThread())
     {
         UE_LOG(LogUmgMcp, Verbose, TEXT("UmgMcpBridge: Already on GameThread, executing directly."));
-        return InternalExecuteCommand(CommandType, Params);
+        TSharedPtr<FQueuedBridgeCommand, ESPMode::ThreadSafe> Direct = MakeShared<FQueuedBridgeCommand, ESPMode::ThreadSafe>();
+        Direct->CommandType = CommandType;
+        Direct->Params = Params;
+        Direct->ClientId = InClientId.IsEmpty() ? TEXT("legacy") : InClientId;
+        Direct->RequestId = InRequestId.IsEmpty() ? FGuid::NewGuid().ToString(EGuidFormats::Digits) : InRequestId;
+        Direct->RawRequestJson = RawRequestJson;
+        Direct->Sequence = ++NextSequence;
+        Direct->EnqueuedAt = FPlatformTime::Seconds();
+        return ExecuteQueuedCommand(Direct);
     }
     
     // Otherwise, queue execution on Game Thread and wait
@@ -276,16 +371,38 @@ FString UUmgMcpBridge::ExecuteCommand(const FString& CommandType, const TSharedP
     QueuedCommand->CommandType = CommandType;
     QueuedCommand->Params = Params;
     QueuedCommand->CompletionEvent = CompletionEvent;
+    QueuedCommand->ClientId = InClientId.IsEmpty() ? TEXT("legacy") : InClientId;
+    QueuedCommand->RequestId = InRequestId.IsEmpty() ? FGuid::NewGuid().ToString(EGuidFormats::Digits) : InRequestId;
+    QueuedCommand->RawRequestJson = RawRequestJson;
+    QueuedCommand->Sequence = ++NextSequence;
+    QueuedCommand->EnqueuedAt = FPlatformTime::Seconds();
+
+    AddDebugRecord(*QueuedCommand, TEXT("queued"), TEXT(""), 0.0);
 
     bool bShouldScheduleProcessor = false;
+    bool bRejectedDuringShutdown = false;
     {
         FScopeLock CommandLock(&CommandQueueCs);
-        CommandQueue.Add(QueuedCommand);
-        if (!bCommandQueueProcessing)
+        if (!bIsRunning)
         {
-            bCommandQueueProcessing = true;
-            bShouldScheduleProcessor = true;
+            bRejectedDuringShutdown = true;
         }
+        else
+        {
+            CommandQueue.Add(QueuedCommand);
+            if (!bCommandQueueProcessing)
+            {
+                bCommandQueueProcessing = true;
+                bShouldScheduleProcessor = true;
+            }
+        }
+    }
+
+    if (bRejectedDuringShutdown)
+    {
+        FPlatformProcess::ReturnSynchEventToPool(CompletionEvent);
+        QueuedCommand->CompletionEvent = nullptr;
+        return MakeErrorResponse(TEXT("UmgMcp server is shutting down."), TEXT("server_stopping"));
     }
 
     if (bShouldScheduleProcessor)
@@ -322,7 +439,7 @@ void UUmgMcpBridge::ProcessNextQueuedCommand()
 
     if (QueuedCommand.IsValid())
     {
-        QueuedCommand->Response = InternalExecuteCommand(QueuedCommand->CommandType, QueuedCommand->Params);
+        QueuedCommand->Response = ExecuteQueuedCommand(QueuedCommand);
         if (QueuedCommand->CompletionEvent)
         {
             QueuedCommand->CompletionEvent->Trigger();
@@ -346,6 +463,331 @@ void UUmgMcpBridge::ProcessNextQueuedCommand()
             ProcessNextQueuedCommand();
         });
     }
+}
+
+FString UUmgMcpBridge::MakeErrorResponse(const FString& Error, const FString& Code) const
+{
+    TSharedRef<FJsonObject> Json = MakeShared<FJsonObject>();
+    Json->SetStringField(TEXT("status"), TEXT("error"));
+    Json->SetStringField(TEXT("error"), Error);
+    if (!Code.IsEmpty())
+    {
+        Json->SetStringField(TEXT("code"), Code);
+    }
+
+    FString Result;
+    FJsonSerializer::Serialize(Json, TJsonWriterFactory<>::Create(&Result));
+    return Result;
+}
+
+void UUmgMcpBridge::AddDebugRecord(const FQueuedBridgeCommand& Command, const FString& State, const FString& Response, double DurationMs)
+{
+    FMcpDebugRecord Record;
+    Record.Sequence = Command.Sequence;
+    Record.Time = FDateTime::Now().ToString(TEXT("%H:%M:%S.%s"));
+    Record.ClientId = Command.ClientId;
+    Record.RequestId = Command.RequestId;
+    Record.Command = Command.CommandType;
+    Record.RequestJson = Command.RawRequestJson;
+    Record.ResponseJson = Response;
+    Record.State = State;
+    Record.DurationMs = DurationMs;
+
+    FScopeLock Lock(&DebugRecordsCs);
+    // Replace the queued row when the same request reaches a terminal state.
+    const int32 Existing = DebugRecords.IndexOfByPredicate([&Record](const FMcpDebugRecord& Item)
+    {
+        return Item.Sequence == Record.Sequence;
+    });
+    if (Existing != INDEX_NONE)
+    {
+        DebugRecords[Existing] = MoveTemp(Record);
+    }
+    else
+    {
+        DebugRecords.Add(MoveTemp(Record));
+    }
+    constexpr int32 MaxDebugRecords = 500;
+    if (DebugRecords.Num() > MaxDebugRecords)
+    {
+        DebugRecords.RemoveAt(0, DebugRecords.Num() - MaxDebugRecords);
+    }
+}
+
+void UUmgMcpBridge::GetDebugRecords(TArray<FMcpDebugRecord>& OutRecords) const
+{
+    FScopeLock Lock(&DebugRecordsCs);
+    OutRecords = DebugRecords;
+}
+
+FString UUmgMcpBridge::ExecuteDebugMessage(const FString& Message)
+{
+    TSharedPtr<FJsonObject> Json;
+    if (!FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(Message), Json) || !Json.IsValid())
+    {
+        return MakeErrorResponse(TEXT("Debug request is not valid JSON."), TEXT("invalid_json"));
+    }
+
+    FString Command;
+    if (!Json->TryGetStringField(TEXT("command"), Command) || Command.IsEmpty())
+    {
+        return MakeErrorResponse(TEXT("Debug request is missing 'command'."), TEXT("missing_command"));
+    }
+
+    FString ClientId = TEXT("debug-ui");
+    FString RequestId;
+    Json->TryGetStringField(TEXT("client_id"), ClientId);
+    Json->TryGetStringField(TEXT("request_id"), RequestId);
+    TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+    const TSharedPtr<FJsonValue> ParamsValue = Json->TryGetField(TEXT("params"));
+    if (ParamsValue.IsValid() && ParamsValue->Type == EJson::Object)
+    {
+        Params = ParamsValue->AsObject();
+    }
+    return ExecuteCommand(Command, Params, ClientId, RequestId, Message);
+}
+
+bool UUmgMcpBridge::RestoreSessionContext(const FString& ClientId, FString& OutError)
+{
+    if (ClientId.IsEmpty() || ClientId == TEXT("legacy") || !GEditor)
+    {
+        return true;
+    }
+
+    FConnectionSession Session;
+    {
+        FScopeLock Lock(&SessionCs);
+        const FConnectionSession* Existing = Sessions.Find(ClientId);
+        if (!Existing)
+        {
+            OutError = FString::Printf(TEXT("Client '%s' is not connected. Call connect first."), *ClientId);
+            return false;
+        }
+        Session = *Existing;
+    }
+
+    if (UUmgAttentionSubsystem* Attention = GEditor->GetEditorSubsystem<UUmgAttentionSubsystem>())
+    {
+        if (!Session.TargetAsset.IsEmpty() && !Attention->SetTargetUmgAsset(Session.TargetAsset))
+        {
+            OutError = FString::Printf(TEXT("Could not restore target '%s' for client '%s'."), *Session.TargetAsset, *ClientId);
+            return false;
+        }
+        if (!Session.TargetWidget.IsEmpty()) Attention->SetTargetWidget(Session.TargetWidget);
+        Attention->SetTargetGraph(Session.TargetGraph);
+        Attention->SetCursorNode(Session.CursorNode);
+        Attention->SetTargetAnimation(Session.TargetAnimation);
+    }
+    if (!Session.TargetMaterial.IsEmpty())
+    {
+        if (UUmgMcpMaterialSubsystem* Material = GEditor->GetEditorSubsystem<UUmgMcpMaterialSubsystem>())
+        {
+            Material->SetTargetMaterial(Session.TargetMaterial, false);
+        }
+    }
+    return true;
+}
+
+void UUmgMcpBridge::CaptureSessionContext(const FString& ClientId)
+{
+    if (ClientId.IsEmpty() || ClientId == TEXT("legacy") || !GEditor)
+    {
+        return;
+    }
+
+    FScopeLock Lock(&SessionCs);
+    FConnectionSession* Session = Sessions.Find(ClientId);
+    if (!Session)
+    {
+        return;
+    }
+    if (UUmgAttentionSubsystem* Attention = GEditor->GetEditorSubsystem<UUmgAttentionSubsystem>())
+    {
+        Session->TargetAsset = Attention->GetTargetUmgAsset();
+        Session->TargetWidget = Attention->GetTargetWidget();
+        Session->TargetGraph = Attention->GetTargetGraph();
+        Session->CursorNode = Attention->GetCursorNode();
+        Session->TargetAnimation = Attention->GetTargetAnimation();
+    }
+    if (UUmgMcpMaterialSubsystem* Material = GEditor->GetEditorSubsystem<UUmgMcpMaterialSubsystem>())
+    {
+        if (UMaterial* Target = Material->GetTargetMaterial())
+        {
+            Session->TargetMaterial = Target->GetPathName();
+        }
+    }
+    for (auto It = TargetOwners.CreateIterator(); It; ++It)
+    {
+        if (It.Value() == ClientId) It.RemoveCurrent();
+    }
+    if (Session->bExclusiveTargets)
+    {
+        if (!Session->TargetAsset.IsEmpty()) TargetOwners.Add(Session->TargetAsset.ToLower(), ClientId);
+        if (!Session->TargetMaterial.IsEmpty()) TargetOwners.Add(Session->TargetMaterial.ToLower(), ClientId);
+    }
+    Session->LastSeenAt = FDateTime::UtcNow();
+}
+
+bool UUmgMcpBridge::ValidateTargetLease(const FString& ClientId, const FString& CommandType,
+    const TSharedPtr<FJsonObject>& Params, FString& OutError)
+{
+    if (ClientId.IsEmpty() || ClientId == TEXT("legacy") || !Params.IsValid() || IsTargetIndependentCommand(CommandType))
+    {
+        return true;
+    }
+    FString RequestedTarget;
+    if (CommandType == TEXT("set_target_umg_asset"))
+    {
+        Params->TryGetStringField(TEXT("asset_path"), RequestedTarget);
+        FString Left, Right;
+        if (RequestedTarget.Split(TEXT(":"), &Left, &Right)) RequestedTarget = Left;
+    }
+    else if (CommandType == TEXT("material_set_target") || CommandType == TEXT("hlsl_set_target"))
+    {
+        Params->TryGetStringField(TEXT("path"), RequestedTarget);
+    }
+    FScopeLock Lock(&SessionCs);
+    FConnectionSession* Session = Sessions.Find(ClientId);
+    if (!Session) return true;
+    if (RequestedTarget.IsEmpty())
+    {
+        RequestedTarget = (CommandType.StartsWith(TEXT("material_")) || CommandType.StartsWith(TEXT("hlsl_")))
+            ? Session->TargetMaterial : Session->TargetAsset;
+    }
+    if (RequestedTarget.IsEmpty()) return true;
+    const FString Canonical = RequestedTarget.ToLower();
+    if (const FString* Owner = TargetOwners.Find(Canonical))
+    {
+        if (*Owner != ClientId)
+        {
+            OutError = FString::Printf(TEXT("Target '%s' is exclusively bound to client '%s'."), *RequestedTarget, **Owner);
+            return false;
+        }
+    }
+    return true;
+}
+
+FString UUmgMcpBridge::HandleConnectionCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params, const FString& ClientId)
+{
+    TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetStringField(TEXT("status"), TEXT("success"));
+    if (CommandType == TEXT("connect"))
+    {
+        FString EffectiveId = ClientId;
+        if (EffectiveId.IsEmpty() || EffectiveId == TEXT("legacy"))
+        {
+            Params->TryGetStringField(TEXT("client_id"), EffectiveId);
+        }
+        if (EffectiveId.IsEmpty()) EffectiveId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphensLower);
+        FConnectionSession Session;
+        Session.ClientId = EffectiveId;
+        Params->TryGetStringField(TEXT("display_name"), Session.DisplayName);
+        Params->TryGetStringField(TEXT("target"), Session.TargetAsset);
+        Params->TryGetBoolField(TEXT("exclusive"), Session.bExclusiveTargets);
+        Session.ConnectedAt = FDateTime::UtcNow();
+        Session.LastSeenAt = Session.ConnectedAt;
+        if (Session.TargetAsset.IsEmpty() && GEditor)
+        {
+            if (UUmgAttentionSubsystem* Attention = GEditor->GetEditorSubsystem<UUmgAttentionSubsystem>())
+            {
+                Session.TargetAsset = Attention->GetTargetUmgAsset();
+                Session.TargetWidget = Attention->GetTargetWidget();
+                Session.TargetGraph = Attention->GetTargetGraph();
+                Session.CursorNode = Attention->GetCursorNode();
+                Session.TargetAnimation = Attention->GetTargetAnimation();
+            }
+        }
+        {
+            FScopeLock Lock(&SessionCs);
+            if (FConnectionSession* Existing = Sessions.Find(EffectiveId))
+            {
+                const FString PreservedTarget = Existing->TargetAsset;
+                const FString PreservedWidget = Existing->TargetWidget;
+                const FString PreservedMaterial = Existing->TargetMaterial;
+                *Existing = Session;
+                if (Existing->TargetAsset.IsEmpty()) Existing->TargetAsset = PreservedTarget;
+                Existing->TargetWidget = PreservedWidget;
+                Existing->TargetMaterial = PreservedMaterial;
+            }
+            else Sessions.Add(EffectiveId, Session);
+        }
+        Result->SetStringField(TEXT("client_id"), EffectiveId);
+        Result->SetStringField(TEXT("server_instance_id"), ServerInstanceId);
+        Result->SetNumberField(TEXT("port"), Port);
+        Result->SetBoolField(TEXT("exclusive"), Session.bExclusiveTargets);
+    }
+    else if (CommandType == TEXT("disconnect"))
+    {
+        FScopeLock Lock(&SessionCs);
+        Sessions.Remove(ClientId);
+        for (auto It = TargetOwners.CreateIterator(); It; ++It)
+        {
+            if (It.Value() == ClientId) It.RemoveCurrent();
+        }
+        Result->SetStringField(TEXT("client_id"), ClientId);
+    }
+    else if (CommandType == TEXT("server_info") || CommandType == TEXT("list_connections"))
+    {
+        Result->SetStringField(TEXT("server_instance_id"), ServerInstanceId);
+        Result->SetNumberField(TEXT("port"), Port);
+        int32 QueuedRequests = 0;
+        {
+            FScopeLock QueueLock(&CommandQueueCs);
+            QueuedRequests = CommandQueue.Num();
+        }
+        Result->SetNumberField(TEXT("queued_requests"), QueuedRequests);
+        TArray<TSharedPtr<FJsonValue>> Items;
+        FScopeLock Lock(&SessionCs);
+        for (const auto& Pair : Sessions)
+        {
+            TSharedRef<FJsonObject> Item = MakeShared<FJsonObject>();
+            Item->SetStringField(TEXT("client_id"), Pair.Key);
+            Item->SetStringField(TEXT("display_name"), Pair.Value.DisplayName);
+            Item->SetStringField(TEXT("target"), Pair.Value.TargetAsset);
+            Item->SetStringField(TEXT("material_target"), Pair.Value.TargetMaterial);
+            Item->SetBoolField(TEXT("exclusive"), Pair.Value.bExclusiveTargets);
+            Item->SetStringField(TEXT("last_seen"), Pair.Value.LastSeenAt.ToIso8601());
+            Items.Add(MakeShared<FJsonValueObject>(Item));
+        }
+        Result->SetArrayField(TEXT("connections"), Items);
+    }
+    FString Serialized;
+    FJsonSerializer::Serialize(Result, TJsonWriterFactory<>::Create(&Serialized));
+    return Serialized;
+}
+
+FString UUmgMcpBridge::ExecuteQueuedCommand(const TSharedPtr<FQueuedBridgeCommand, ESPMode::ThreadSafe>& Command)
+{
+    const double StartedAt = FPlatformTime::Seconds();
+    FString Response;
+    if (Command->CommandType == TEXT("connect") || Command->CommandType == TEXT("disconnect") ||
+        Command->CommandType == TEXT("server_info") || Command->CommandType == TEXT("list_connections"))
+    {
+        Response = HandleConnectionCommand(Command->CommandType, Command->Params, Command->ClientId);
+    }
+    else
+    {
+        FString Error;
+        if (!RestoreSessionContext(Command->ClientId, Error))
+        {
+            Response = MakeErrorResponse(Error, TEXT("not_connected"));
+        }
+        else if (!ValidateTargetLease(Command->ClientId, Command->CommandType, Command->Params, Error))
+        {
+            Response = MakeErrorResponse(Error, TEXT("target_locked"));
+        }
+        else
+        {
+            Response = InternalExecuteCommand(Command->CommandType, Command->Params);
+            if (!IsTargetIndependentCommand(Command->CommandType))
+            {
+                CaptureSessionContext(Command->ClientId);
+            }
+        }
+    }
+    const double DurationMs = (FPlatformTime::Seconds() - StartedAt) * 1000.0;
+    AddDebugRecord(*Command, Response.Contains(TEXT("\"status\":\"error\"")) ? TEXT("error") : TEXT("completed"), Response, DurationMs);
+    return Response;
 }
 
 FString UUmgMcpBridge::InternalExecuteCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params)

--- a/Source/UmgMcp/Private/Debug/SUmgMcpDebugPanel.cpp
+++ b/Source/UmgMcp/Private/Debug/SUmgMcpDebugPanel.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2025-2026 Winyunq. All rights reserved.
+#include "Debug/SUmgMcpDebugPanel.h"
+
+#include "Bridge/UmgMcpBridge.h"
+#include "Editor.h"
+#include "HAL/PlatformTime.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SSplitter.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+
+#define LOCTEXT_NAMESPACE "SUmgMcpDebugPanel"
+
+void SUmgMcpDebugPanel::Construct(const FArguments& InArgs)
+{
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot().AutoHeight().Padding(6)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().FillWidth(1)
+            [
+                SAssignNew(ServerStatus, STextBlock)
+            ]
+            + SHorizontalBox::Slot().AutoWidth().Padding(4, 0)
+            [
+                SNew(SButton).Text(LOCTEXT("ConnectTemplate", "连接模板"))
+                .OnClicked(this, &SUmgMcpDebugPanel::InsertConnect)
+            ]
+            + SHorizontalBox::Slot().AutoWidth().Padding(4, 0)
+            [
+                SNew(SButton).Text(LOCTEXT("PingTemplate", "Ping 模板"))
+                .OnClicked(this, &SUmgMcpDebugPanel::InsertPing)
+            ]
+            + SHorizontalBox::Slot().AutoWidth()
+            [
+                SNew(SButton).Text(LOCTEXT("Execute", "按真实管线执行"))
+                .OnClicked(this, &SUmgMcpDebugPanel::ExecuteInput)
+            ]
+        ]
+        + SVerticalBox::Slot().FillHeight(0.42f).Padding(6, 0, 6, 3)
+        [
+            SNew(SSplitter)
+            + SSplitter::Slot().Value(0.5f)
+            [
+                SNew(SBorder)
+                [
+                    SAssignNew(RequestEditor, SMultiLineEditableTextBox)
+                    .Text(FText::FromString(TEXT("{\n  \"command\": \"connect\",\n  \"client_id\": \"debug-ui\",\n  \"params\": {\"display_name\": \"Debug UI\", \"exclusive\": true}\n}")))
+                ]
+            ]
+            + SSplitter::Slot().Value(0.5f)
+            [
+                SNew(SBorder)
+                [
+                    SAssignNew(ResponseViewer, SMultiLineEditableTextBox)
+                    .IsReadOnly(true)
+                ]
+            ]
+        ]
+        + SVerticalBox::Slot().FillHeight(0.58f).Padding(6, 3, 6, 6)
+        [
+            SNew(SBorder)
+            [
+                SAssignNew(TraceViewer, SMultiLineEditableTextBox)
+                .IsReadOnly(true)
+            ]
+        ]
+    ];
+    RefreshTrace();
+}
+
+void SUmgMcpDebugPanel::Tick(const FGeometry& AllottedGeometry, double InCurrentTime, float InDeltaTime)
+{
+    SCompoundWidget::Tick(AllottedGeometry, InCurrentTime, InDeltaTime);
+    if (InCurrentTime - LastRefreshAt >= 0.25)
+    {
+        LastRefreshAt = InCurrentTime;
+        RefreshTrace();
+    }
+}
+
+FReply SUmgMcpDebugPanel::ExecuteInput()
+{
+    if (GEditor && RequestEditor.IsValid())
+    {
+        if (UUmgMcpBridge* Bridge = GEditor->GetEditorSubsystem<UUmgMcpBridge>())
+        {
+            ResponseViewer->SetText(FText::FromString(Bridge->ExecuteDebugMessage(RequestEditor->GetText().ToString())));
+            RefreshTrace();
+        }
+    }
+    return FReply::Handled();
+}
+
+FReply SUmgMcpDebugPanel::InsertPing()
+{
+    RequestEditor->SetText(FText::FromString(TEXT("{\n  \"command\": \"ping\",\n  \"client_id\": \"debug-ui\",\n  \"request_id\": \"manual-ping\",\n  \"params\": {}\n}")));
+    return FReply::Handled();
+}
+
+FReply SUmgMcpDebugPanel::InsertConnect()
+{
+    RequestEditor->SetText(FText::FromString(TEXT("{\n  \"command\": \"connect\",\n  \"client_id\": \"debug-ui\",\n  \"params\": {\"display_name\": \"Debug UI\", \"exclusive\": true}\n}")));
+    return FReply::Handled();
+}
+
+void SUmgMcpDebugPanel::RefreshTrace()
+{
+    if (!GEditor || !TraceViewer.IsValid()) return;
+    UUmgMcpBridge* Bridge = GEditor->GetEditorSubsystem<UUmgMcpBridge>();
+    if (!Bridge) return;
+
+    ServerStatus->SetText(FText::Format(LOCTEXT("ServerStatus", "实例 {0}  |  127.0.0.1:{1}  |  所有请求 FIFO 串行执行"),
+        FText::FromString(Bridge->GetServerInstanceId()), FText::AsNumber(Bridge->GetListeningPort())));
+    TArray<FMcpDebugRecord> Records;
+    Bridge->GetDebugRecords(Records);
+    FString Trace;
+    for (const FMcpDebugRecord& Record : Records)
+    {
+        Trace += FString::Printf(TEXT("#%llu  %s  [%s]  client=%s  request=%s  command=%s  %.2f ms\n> %s\n< %s\n\n"),
+            Record.Sequence, *Record.Time, *Record.State, *Record.ClientId, *Record.RequestId,
+            *Record.Command, Record.DurationMs, *Record.RequestJson, *Record.ResponseJson);
+    }
+    TraceViewer->SetText(FText::FromString(Trace));
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/UmgMcp/Private/UmgMcp.cpp
+++ b/Source/UmgMcp/Private/UmgMcp.cpp
@@ -1,27 +1,38 @@
 // Copyright (c) 2025-2026 Winyunq. All rights reserved.
 #include "UmgMcp.h"
-#include "Bridge/UmgMcpConfig.h" // Include our config header
+#include "Bridge/UmgMcpConfig.h"
+#include "Debug/SUmgMcpDebugPanel.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
 
 DEFINE_LOG_CATEGORY(LogUmgMcp);
 
 #define LOCTEXT_NAMESPACE "FUmgMcpModule"
 
+static const FName UmgMcpDebugTabName("UmgMcpDebug");
+
 void FUmgMcpModule::StartupModule()
 {
-	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
-	UE_LOG(LogUmgMcp, Warning, TEXT("UMG agent Start!"));
+    UE_LOG(LogUmgMcp, Warning, TEXT("UMG agent Start!"));
+    UE_LOG(LogUmgMcp, Display, TEXT("UmgMcp is running at default port: %d"), MCP_SERVER_PORT_DEFAULT);
 
-	// The UmgAttentionSubsystem is automatically initialized by the engine.
-
-	// Use the hardcoded default port from UmgMcpConfig.h
-	int32 Port = MCP_SERVER_PORT_DEFAULT;
-	UE_LOG(LogUmgMcp, Display, TEXT("UmgMcp is running at: %d"), Port);
+    FGlobalTabmanager::Get()->RegisterNomadTabSpawner(UmgMcpDebugTabName, FOnSpawnTab::CreateLambda([](const FSpawnTabArgs& Args)
+    {
+        return SNew(SDockTab)
+            .TabRole(ETabRole::NomadTab)
+            [
+                SNew(SUmgMcpDebugPanel)
+            ];
+    }))
+    .SetDisplayName(LOCTEXT("UmgMcpDebugTabTitle", "UMG MCP Debug Console"))
+    .SetTooltipText(LOCTEXT("UmgMcpDebugTooltip", "Inspect and simulate raw AI protocol messages"))
+    .SetGroup(WorkspaceMenu::GetMenuStructure().GetToolsCategory());
 }
 
 void FUmgMcpModule::ShutdownModule()
 {
-	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-	// we call this function before unloading the module.
+    FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(UmgMcpDebugTabName);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/UmgMcp/Public/Bridge/MCPServerRunnable.h
+++ b/Source/UmgMcp/Public/Bridge/MCPServerRunnable.h
@@ -5,6 +5,7 @@
 #include "HAL/Runnable.h"
 #include "Sockets.h"
 #include "Interfaces/IPv4/IPv4Address.h"
+#include "HAL/CriticalSection.h"
 
 class UUmgMcpBridge;
 
@@ -37,5 +38,8 @@ private:
 	UUmgMcpBridge* Bridge;
 	TSharedPtr<FSocket> ListenerSocket;
 	TSharedPtr<FSocket> ClientSocket;
-	bool bRunning;
-}; 
+	TAtomic<bool> bRunning;
+	TAtomic<int32> ActiveConnectionCount;
+	FCriticalSection ActiveSocketsCs;
+	TArray<TSharedPtr<FSocket>> ActiveSockets;
+};

--- a/Source/UmgMcp/Public/Bridge/UmgMcpBridge.h
+++ b/Source/UmgMcp/Public/Bridge/UmgMcpBridge.h
@@ -28,6 +28,19 @@ class FUmgMcpFileTransformationCommands; // Forward declaration for File Transfo
 class FUmgMcpSequencerCommands; // Forward declaration for Sequencer Commands
 class FUmgMcpMaterialCommands; // Forward declaration for Material Commands
 
+struct FMcpDebugRecord
+{
+    uint64 Sequence = 0;
+    FString Time;
+    FString ClientId;
+    FString RequestId;
+    FString Command;
+    FString RequestJson;
+    FString ResponseJson;
+    FString State;
+    double DurationMs = 0.0;
+};
+
 /**
  * @brief The central communication hub for the UMG MCP plugin.
  *
@@ -56,7 +69,15 @@ public:
 	bool IsRunning() const { return bIsRunning; }
 
 	// Command execution
-	FString ExecuteCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params);
+	FString ExecuteCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params,
+        const FString& ClientId = TEXT(""), const FString& RequestId = TEXT(""),
+        const FString& RawRequestJson = TEXT(""));
+
+    /** Executes exactly the same protocol path used by TCP clients, for the Debug UI. */
+    FString ExecuteDebugMessage(const FString& Message);
+    void GetDebugRecords(TArray<FMcpDebugRecord>& OutRecords) const;
+    int32 GetListeningPort() const { return Port; }
+    FString GetServerInstanceId() const { return ServerInstanceId; }
 
 private:
     struct FQueuedBridgeCommand
@@ -65,11 +86,38 @@ private:
         TSharedPtr<FJsonObject> Params;
         FString Response;
         FEvent* CompletionEvent = nullptr;
+        FString ClientId;
+        FString RequestId;
+        FString RawRequestJson;
+        uint64 Sequence = 0;
+        double EnqueuedAt = 0.0;
+    };
+
+    struct FConnectionSession
+    {
+        FString ClientId;
+        FString DisplayName;
+        FString TargetAsset;
+        FString TargetWidget;
+        FString TargetGraph;
+        FString CursorNode;
+        FString TargetAnimation;
+        FString TargetMaterial;
+        bool bExclusiveTargets = true;
+        FDateTime ConnectedAt;
+        FDateTime LastSeenAt;
     };
 
     // Internal helper to execute command logic (thread-agnostic)
     FString InternalExecuteCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params);
     void ProcessNextQueuedCommand();
+    FString ExecuteQueuedCommand(const TSharedPtr<FQueuedBridgeCommand, ESPMode::ThreadSafe>& QueuedCommand);
+    FString HandleConnectionCommand(const FString& CommandType, const TSharedPtr<FJsonObject>& Params, const FString& ClientId);
+    bool RestoreSessionContext(const FString& ClientId, FString& OutError);
+    void CaptureSessionContext(const FString& ClientId);
+    bool ValidateTargetLease(const FString& ClientId, const FString& CommandType, const TSharedPtr<FJsonObject>& Params, FString& OutError);
+    void AddDebugRecord(const FQueuedBridgeCommand& Command, const FString& State, const FString& Response, double DurationMs);
+    FString MakeErrorResponse(const FString& Error, const FString& Code = TEXT("")) const;
 
     TSharedPtr<FUmgMcpEditorCommands> EditorCommands;
     TSharedPtr<FUmgMcpBlueprintCommands> BlueprintCommands;
@@ -84,11 +132,20 @@ private:
     TSharedPtr<FSocket> ListenerSocket;
     TSharedPtr<FSocket> ConnectionSocket;
     FRunnableThread* ServerThread;
+    FMCPServerRunnable* ServerRunnable;
     int32 Port;
     FIPv4Address ServerAddress;
     FCriticalSection CommandQueueCs;
     TArray<TSharedPtr<FQueuedBridgeCommand, ESPMode::ThreadSafe>> CommandQueue;
     bool bCommandQueueProcessing;
+    TAtomic<uint64> NextSequence;
+    FString ServerInstanceId;
+    FString DiscoveryFilePath;
+    mutable FCriticalSection SessionCs;
+    TMap<FString, FConnectionSession> Sessions;
+    TMap<FString, FString> TargetOwners;
+    mutable FCriticalSection DebugRecordsCs;
+    TArray<FMcpDebugRecord> DebugRecords;
 
     // Static flag to prevent multiple instances from trying to bind the same port
     static bool bGlobalServerStarted;

--- a/Source/UmgMcp/Public/Debug/SUmgMcpDebugPanel.h
+++ b/Source/UmgMcp/Public/Debug/SUmgMcpDebugPanel.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2025-2026 Winyunq. All rights reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+
+class SMultiLineEditableTextBox;
+class STextBlock;
+
+/** Protocol console backed by UUmgMcpBridge's real request pipeline. */
+class UMGMCP_API SUmgMcpDebugPanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SUmgMcpDebugPanel) {}
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+    virtual void Tick(const FGeometry& AllottedGeometry, double InCurrentTime, float InDeltaTime) override;
+
+private:
+    FReply ExecuteInput();
+    FReply InsertPing();
+    FReply InsertConnect();
+    void RefreshTrace();
+
+    TSharedPtr<SMultiLineEditableTextBox> RequestEditor;
+    TSharedPtr<SMultiLineEditableTextBox> ResponseViewer;
+    TSharedPtr<SMultiLineEditableTextBox> TraceViewer;
+    TSharedPtr<STextBlock> ServerStatus;
+    double LastRefreshAt = 0.0;
+};

--- a/Source/UmgMcp/UmgMcp.Build.cs
+++ b/Source/UmgMcp/UmgMcp.Build.cs
@@ -58,7 +58,8 @@ public class UmgMcp : ModuleRules
 				"Projects",
 				"AssetRegistry",
 				"UMGEditor", // Moved from PublicDependencyModuleNames
-				"MaterialEditor" // For Material Editing Libraries
+				"MaterialEditor", // For Material Editing Libraries
+				"WorkspaceMenuStructure"
 
 			}
 		);


### PR DESCRIPTION
## What changed

- accept concurrent MCP socket clients while serializing Unreal Editor work through a single FIFO
- isolate UMG, Blueprint, animation, and material targets by stable client session
- add exclusive target leases and structured `target_locked` errors
- expose local UE instance discovery, explicit connection tools, and dynamic-port fallback
- add a raw-protocol Debug Console backed by the production request path

## Why

The public MCP bridge previously blocked on one socket and relied on shared global target state. Multiple AI clients could therefore overwrite each other's context or edit the wrong asset.

## Public-edition adaptation

The Debug Console is registered by the lightweight public module entry point. No FabServer, ChatWithUnreal, or LiteRT dependencies are included.

## Validation

- Python syntax and concurrent session protocol tests passed
- UE 5.8 `BuildPlugin` completed successfully for Win64
- real UE TCP test passed with eight concurrent sockets and two client sessions
- exclusive target conflict and independent-target recovery passed
- occupied default-port test successfully selected a dynamic port
